### PR TITLE
Tool: cancel DIP-C write when in FPGA 

### DIFF
--- a/src/main/scala/utility/ChiselDB.scala
+++ b/src/main/scala/utility/ChiselDB.scala
@@ -207,6 +207,12 @@ private class TableWriteHelper[T <: Record](tableName: String, hw: T, site: Stri
 object ChiselDB {
 
   private val table_map = scala.collection.mutable.Map[String, Table[_]]()
+  private var envInFPGA = false
+
+  def init(envInFPGA: Boolean): Unit = {
+    // Not needed at the moment
+    this.envInFPGA = envInFPGA
+  }
 
   def createTable[T <: Record](tableName: String, hw: T): Table[T] = {
     table_map

--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -74,23 +74,26 @@ object Constantin extends ConstantinParams {
   private val recordMap = scala.collection.mutable.Map[String, UInt]()
   private val objectName = "constantin"
 
-  def createRecord(constName: String): UInt = {
-    val t = WireInit(0.U.asTypeOf(UInt(UIntWidth.W)))
+  def createRecord(envInFPGA: Boolean, constName: String, initValue: UInt = 0.U): UInt = {
+    val t = WireInit(initValue.asTypeOf(UInt(UIntWidth.W)))
     if (recordMap.contains(constName)) {
       recordMap.getOrElse(constName, 0.U)
     } else {
       recordMap += (constName -> t)
-      val recordModule = Module(new SignalReadHelper(constName))
-      //recordModule.io.clock := Clock()
-      //recordModule.io.reset := Reset()
-      t := recordModule.io.value
+       if (envInFPGA) {
+         println(s"Constantin initRead: ${constName} = ${initValue}")
+         recordMap.getOrElse(constName, 0.U)
+       } else {
+        val recordModule = Module(new SignalReadHelper(constName))
+        //recordModule.io.clock := Clock()
+        //recordModule.io.reset := Reset()
+        t := recordModule.io.value
 
-      // print record info
-      println(s"Constantin ${constName}")
-
-      t
+        // print record info
+         println(s"Constantin fileRead: ${constName} = ${initValue}")
+        t
+       }
     }
-
   }
 
   def getCHeader: String = {

--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -73,8 +73,13 @@ class MuxModule[A <: Record](gen: A, n: Int) extends Module {
 object Constantin extends ConstantinParams {
   private val recordMap = scala.collection.mutable.Map[String, UInt]()
   private val objectName = "constantin"
+  private var envInFPGA = false
 
-  def createRecord(envInFPGA: Boolean, constName: String, initValue: UInt = 0.U): UInt = {
+  def init(envInFPGA: Boolean): Unit = {
+    this.envInFPGA = envInFPGA
+  }
+
+  def createRecord(constName: String, initValue: UInt = 0.U): UInt = {
     val t = WireInit(initValue.asTypeOf(UInt(UIntWidth.W)))
     if (recordMap.contains(constName)) {
       recordMap.getOrElse(constName, 0.U)


### PR DESCRIPTION
1. Constantin: When FPAG is enabled, constantin switches from file read to initialization parameter.
2. ChiselDB: add envInFPGA member variables for later use