### PR TITLE
add RegisterSlice.scala

### DIFF
--- a/src/main/scala/utility/RegisterSlice.scala
+++ b/src/main/scala/utility/RegisterSlice.scala
@@ -1,0 +1,141 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+import chisel3._
+import chisel3.util._
+
+abstract class RegisterSlice[T<: Data](gen: T) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(DecoupledIO(gen.cloneType))
+    val out = DecoupledIO(gen.cloneType)
+    val flush = Input(Bool())
+  })
+}
+
+class ForwardRegistered[T<: Data](gen: T) extends RegisterSlice[T](gen) {
+
+  val valid = RegInit(false.B)
+  when (io.out.ready) { valid := false.B }
+  when (io.in.valid) { valid := true.B }
+  when (io.flush) { valid := false.B }
+
+  val payload = RegEnable(io.in.bits, io.in.fire)
+
+  io.out.valid := valid
+  io.out.bits := payload
+  io.in.ready := io.out.ready | !valid
+}
+
+class BackwardRegistered[T<: Data](gen: T) extends RegisterSlice[T](gen) {
+
+  val ready = RegInit(true.B)
+  val valid_buf = RegInit(false.B)
+  val payload_buf = RegInit(0.U.asTypeOf(gen))
+  val is_buf_full = RegInit(false.B)
+
+  when (io.in.valid & !io.out.ready) {
+    is_buf_full := true.B
+    valid_buf := true.B
+    payload_buf := io.in.bits
+    ready := false.B
+  }
+
+  when (is_buf_full & io.out.ready) {
+    is_buf_full := false.B
+    valid_buf := false.B
+    ready := true.B
+  }
+
+  when (io.flush) {
+    ready := true.B
+    valid_buf := false.B
+    is_buf_full := false.B
+  }
+
+  io.out.valid := Mux(is_buf_full, valid_buf, io.in.valid)
+  io.out.bits := Mux(is_buf_full, payload_buf, io.in.bits)
+  io.in.ready := ready
+}
+
+class FullyRegistered[T<: Data](gen: T) extends RegisterSlice[T](gen) {
+
+  val in_ready = RegInit(true.B)
+  val out_valid = RegInit(false.B)
+
+  val payload_buf, out_payload = RegInit(0.U.asTypeOf(gen))
+
+  val s_empty :: s_busy :: s_full :: Nil = Enum(3)
+  val state = RegInit(s_empty)
+
+  switch(state) {
+    is (s_empty) {
+      when (io.in.fire) {
+        out_valid := true.B
+        out_payload := io.in.bits
+        state := s_busy
+      }
+    }
+    is (s_busy) {
+      when (io.in.fire && io.out.fire) {
+        out_payload := io.in.bits
+      }
+      when (!io.in.fire && io.out.fire) {
+        out_valid := false.B
+        state := s_empty
+      }
+      when (io.in.fire && !io.out.fire) {
+        in_ready := false.B
+        payload_buf := io.in.bits
+        state := s_full
+      }
+    }
+    is (s_full) {
+      when (io.out.fire) {
+        in_ready := true.B
+        out_payload := payload_buf
+        state := s_busy
+      }
+    }
+  }
+
+  when (io.flush) {
+    in_ready := true.B
+    out_valid := false.B
+    state := s_empty
+  }
+
+  io.out.valid := out_valid
+  io.out.bits := out_payload
+  io.in.ready := in_ready
+}
+
+
+object RegisterSlice {
+  def fromString[T <: Data](s: String, gen: T): RegisterSlice[T] = s.toLowerCase match {
+    case "forward"  => Module(new ForwardRegistered(gen))
+    case "backward" => Module(new BackwardRegistered(gen))
+    case "fully"    => Module(new FullyRegistered(gen))
+    case t          => throw new IllegalArgumentException(s"unknown RegisterSlice type $t")
+  }
+
+  def apply[T <: Data](left: DecoupledIO[T], right: DecoupledIO[T],flush: Bool, mode: String): RegisterSlice[T] = {
+    val slice = fromString(mode, left.bits)
+    slice.io.in <> left
+    slice.io.out <> right
+    slice.io.flush := flush
+    slice
+  }
+}

--- a/src/main/scala/utility/RegisterSlice.scala
+++ b/src/main/scala/utility/RegisterSlice.scala
@@ -46,19 +46,24 @@ class BackwardRegistered[T<: Data](gen: T) extends RegisterSlice[T](gen) {
   val payload_buf = RegInit(0.U.asTypeOf(gen))
   val is_buf_full = RegInit(false.B)
 
-  when (io.in.valid & !io.out.ready) {
-    is_buf_full := true.B
-    valid_buf := true.B
-    payload_buf := io.in.bits
-    ready := false.B
+  switch (is_buf_full) {
+    is (false.B) {
+      when (io.in.valid & !io.out.ready) {
+        is_buf_full := true.B
+        valid_buf := true.B
+        payload_buf := io.in.bits
+        ready := false.B
+      }
+    }
+    is (true.B) {
+      when (io.out.ready) {
+        is_buf_full := false.B
+        valid_buf := false.B
+        ready := true.B
+      }
+    }
   }
-
-  when (is_buf_full & io.out.ready) {
-    is_buf_full := false.B
-    valid_buf := false.B
-    ready := true.B
-  }
-
+  
   when (io.flush) {
     ready := true.B
     valid_buf := false.B


### PR DESCRIPTION
Register Slice has three types, Mainly used to handle timing problem：
## Forward Registered
![image-20230414153628528](https://user-images.githubusercontent.com/97723705/231978542-f0309616-8edd-4d79-b846-7df25449f31e.png)

## Backward Registered
![image-20230414153650136](https://user-images.githubusercontent.com/97723705/231978624-14067447-28db-43b0-b6c6-01f816623651.png)
## Fully Registered
- also called skid buffer

![image-20230414153703441](https://user-images.githubusercontent.com/97723705/231978665-fd91d1ed-c37a-4e1f-acf4-388b1af6b596.png)

## Latency & timing
<html>
<body>
<!--StartFragment--><!DOCTYPE html><br class="Apple-interchange-newline">

  | Forward Registered | Backward Registered | Fully Registered
-- | -- | -- | --
Latency | 1 | 0 | 1
io.in.ready | comb with io.out.ready | reg out | reg out
io.out.bits | reg out | comb with io.in.bits | reg out
io.out.valid | reg out | comb with io.in.valid | reg out

<!--EndFragment-->
</body>
</html>

- Latency means from io.in.fire to io.out.fire