### PR TITLE
fix: constantin init when load from stdin

### DIFF
--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -175,6 +175,7 @@ object Constantin extends ConstantinParams {
        |extern map<string, uint64_t> constantinMap;
        |
        |void constantinLoad() {
+       |  constantinInit();
        |  uint64_t num;
        |  string tmp;
        |  uint64_t total_num;


### PR DESCRIPTION
`getPreProcessFromStdInCpp` in `src/main/scala/utility/Constantin.scala` is missing a call to `constantinInit();`, resulting in all constants being setting to zero when only a subset of constants is provided through standard input. Fix it.

`src/main/scala/utility/Constantin.scala` 中的 `getPreProcessFromStdInCpp` 漏掉了初始化函数 `constantinInit();`。这使得，开启 `AutoSolving` 选项后（即从标准输入流输入），如果只提供一部分常量时，其他所有常量都会被错误地设为 0。修复了这个问题。