### PR TITLE
Constantin: avoid assigning DPI-C value to wire directly

### DIFF
--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -45,10 +45,10 @@ private class SignalReadHelper(constName: String) extends BlackBox with HasBlack
        |import "DPI-C" function longint $dpicFunc();
        |
        |module $moduleName(
-       |  output [$UIntWidth - 1:0] value
+       |  output reg [$UIntWidth - 1:0] value
        |);
        |
-       |  assign value = $dpicFunc();
+       |  initial value = $dpicFunc();
        |endmodule
        |""".stripMargin
   setInline(s"$moduleName.v", verilog)


### PR DESCRIPTION
This should partially resolve https://github.com/OpenXiangShan/XiangShan/issues/2561.

This PR should be squash and merge.