### PR TITLE
chore: replace deprecated APIs

### DIFF
--- a/src/main/scala/utility/LookupTree.scala
+++ b/src/main/scala/utility/LookupTree.scala
@@ -26,7 +26,7 @@ object LookupTree {
 
 object LookupTreeDefault {
   def apply[T <: Data](key: UInt, default: T, mapping: Iterable[(UInt, T)]): T =
-    MuxLookup(key, default, mapping.toSeq)
+    MuxLookup(key, default)(mapping.toSeq)
 }
 
 

--- a/src/main/scala/utility/MIMOQueue.scala
+++ b/src/main/scala/utility/MIMOQueue.scala
@@ -17,7 +17,8 @@
 package utility
 
 import chisel3._
-import chisel3.experimental.{DataMirror, requireIsChiselType}
+import chisel3.experimental.requireIsChiselType
+import chisel3.reflect.DataMirror
 import chisel3.util._
 
 class IndexableMem[T <: Data]


### PR DESCRIPTION
Some deprecated APIs in chisel 3.6.0 have been deleted in chisel 6.0.0-RC2. This PR replaces them.