### PR TITLE
Fix switch chisel db

### DIFF
--- a/src/main/scala/utility/ChiselDB.scala
+++ b/src/main/scala/utility/ChiselDB.scala
@@ -231,10 +231,10 @@ object ChiselDB {
     this.enable = enable
   }
 
-  def createTable[T <: Record](tableName: String, hw: T, basicDB: Boolean = this.enable): Table[T] = {
+  def createTable[T <: Record](tableName: String, hw: T, basicDB: Boolean = false.B): Table[T] = {
     getTable(tableName, hw)
       .getOrElse({
-        val t = new Table[T](!basicDB, tableName, hw)
+        val t = new Table[T](!(basicDB & this.enable), tableName, hw)
         table_map += (tableName -> t)
         t
       })


### PR DESCRIPTION
you can close the ChiselDB only using `WITH_CHISELDB=0` in Makefile with no business of `basicDB`.