### PR TITLE
Constantin: use compile-time env if possible

### DIFF
--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -133,9 +133,14 @@ object Constantin extends ConstantinParams {
        |void constantinLoad() {
        |  constantinInit();
        |  uint64_t num;
-       |  string tmp;
-       |  string noop_home = getenv("NOOP_HOME");
-       |  tmp = noop_home + "/build/${objectName}.txt";
+       |  const char *noop_home = getenv("NOOP_HOME");
+       |#ifdef NOOP_HOME
+       |  if (!noop_home) {
+       |    noop_home = NOOP_HOME;
+       |  }
+       |#endif
+       |  string noop_home_s = noop_home;
+       |  string tmp = noop_home_s + "/build/${objectName}.txt";
        |  cf.open(tmp.c_str(), ios::in);
        |  if(cf.good()){
        |    while (cf >> tmp >> num) {
@@ -215,4 +220,3 @@ object Constantin extends ConstantinParams {
   }
 
 }
-


### PR DESCRIPTION
Constantin reads the NOOP_HOME env dynamically during simulation. This requires the env to be always set during simulation time. However, this requirement seems useless as the user seldom changes the env path.

This commit adds the compile-time NOOP_HOME variable as the fallback option if the env variable is not set during simulation time.