### PR TITLE
util: remove cloneType in ParallelMux

### DIFF
--- a/src/main/scala/utility/ParallelMux.scala
+++ b/src/main/scala/utility/ParallelMux.scala
@@ -61,7 +61,7 @@ object ParallelXOR {
 
 object ParallelMux {
   def apply[T<:Data](in: Seq[(Bool, T)]): T = {
-    val xs = in map { case (cond, x) => Mux(cond, x, 0.U.asTypeOf(x.cloneType)) }
+    val xs = in map { case (cond, x) => Mux(cond, x, 0.U.asTypeOf(x)) }
     ParallelOR(xs)
   }
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = apply(sel.zip(in))


### PR DESCRIPTION
<img width="1103" alt="Screenshot 2024-05-09 at 12 51 29" src="https://github.com/OpenXiangShan/Utility/assets/19954398/474ad75f-f4bc-41b8-93c8-6122646b7b29">
<img width="1335" alt="Screenshot 2024-05-09 at 12 51 34" src="https://github.com/OpenXiangShan/Utility/assets/19954398/3c103970-2333-41cf-b0af-f9b64f2241fb">
<img width="1130" alt="Screenshot 2024-05-09 at 12 51 43" src="https://github.com/OpenXiangShan/Utility/assets/19954398/4acae588-c836-435a-8949-58c162a51078">

According to these profiler results, `ParallelMux` in TLB is causing around 5% verilog generation time.
This PR remove the `cloneType` in `0.U.asTypeOf()`