### PR TITLE
clockgate: add more methods and fix original bug

### DIFF
--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -26,3 +26,15 @@ object GatedValidRegNext {
     last
   }
 }
+
+object GatedValidRegNextN {
+  def apply(in: Bool, n: Int, initOpt: Option[Bool] = None): Bool = {
+    (0 until n).foldLeft(in){
+      (prev, _) =>
+        initOpt match {
+          case Some(init) => GatedValidRegNext(prev, init)
+          case None => GatedValidRegNext(prev)
+        }
+    }
+  }
+}

--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -21,13 +21,13 @@ import chisel3.util._
 
 object GatedValidRegNext {
   def apply(next: Bool, init: Bool = false.B): Bool = {
-    val last = Wire(next.cloneType)
+    val last = Wire(chiselTypeOf(next))
     last := RegEnable(next, init, next || last)
     last
   }
 
   def apply(last: Vec[Bool]): Vec[Bool] = {
-    val next = Wire(last.cloneType)
+    val next = Wire(chiselTypeOf(last))
     next := RegEnable(last, last.asUInt.orR || next.asUInt.orR)
     next
   }
@@ -47,7 +47,7 @@ object GatedValidRegNextN {
 
 object GatedRegNext{
   def apply[T <: Data](last: T, initOpt: Option[T] = None): T = {
-    val next = Wire(last.cloneType)
+    val next = Wire(chiselTypeOf(last))
     initOpt match {
       case Some(init) => next := RegEnable(last, init, (last.asUInt ^ next.asUInt).orR)
       case None => next := RegEnable(last, (last.asUInt ^ next.asUInt).orR)

--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -20,14 +20,16 @@ import chisel3._
 import chisel3.util._
 
 object GatedValidRegNext {
+  // 3 is the default minimal width of EDA inserted clock gating cells.
+  // so using `GatedValidRegNext` to signals whoes width is less than 3 may not help.
   def apply(next: Bool, init: Bool = false.B): Bool = {
-    val last = Wire(chiselTypeOf(next))
+    val last = Wire(Bool())
     last := RegEnable(next, init, next || last)
     last
   }
 
   def apply(last: Vec[Bool]): Vec[Bool] = {
-    val next = Wire(chiselTypeOf(last))
+    val next = Wire(last)
     next := RegEnable(last, last.asUInt.orR || next.asUInt.orR)
     next
   }
@@ -47,10 +49,10 @@ object GatedValidRegNextN {
 
 object GatedRegNext{
   def apply[T <: Data](last: T, initOpt: Option[T] = None): T = {
-    val next = Wire(chiselTypeOf(last))
+    val next = Wire(last)
     initOpt match {
-      case Some(init) => next := RegEnable(last, init, (last.asUInt ^ next.asUInt).orR)
-      case None => next := RegEnable(last, (last.asUInt ^ next.asUInt).orR)
+      case Some(init) => next := RegEnable(last, init, last.asUInt =/= next.asUInt)
+      case None => next := RegEnable(last, last.asUInt =/= next.asUInt)
     }
     next
   }

--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -44,3 +44,22 @@ object GatedValidRegNextN {
     }
   }
 }
+
+object GatedRegNext{
+  def apply[T <: Data](last: T, initOpt: Option[T] = None): T = {
+    val next = Wire(last.cloneType)
+    initOpt match {
+      case Some(init) => next := RegEnable(last, init, (last.asUInt ^ next.asUInt).orR)
+      case None => next := RegEnable(last, (last.asUInt ^ next.asUInt).orR)
+    }
+    next
+  }
+}
+
+object GatedRegNextN {
+  def apply[T <: Data](in: T, n: Int, initOpt: Option[T] = None): T = {
+    (0 until n).foldLeft(in){
+      (prev, _) => GatedRegNext(prev, initOpt)
+    }
+  }
+}

--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -25,6 +25,12 @@ object GatedValidRegNext {
     last := RegEnable(next, init, next || last)
     last
   }
+
+  def apply(last: Vec[Bool]): Vec[Bool] = {
+    val next = Wire(last.cloneType)
+    next := RegEnable(last, last.asUInt.orR || next.asUInt.orR)
+    next
+  }
 }
 
 object GatedValidRegNextN {

--- a/src/main/scala/utility/Hold.scala
+++ b/src/main/scala/utility/Hold.scala
@@ -137,7 +137,7 @@ object DelayNWithValid{
     val pipMod = Module(new DelayNWithValid(chiselTypeOf(in.bits), n))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = Wire(chiselTypeOf(in))
+    val res = Wire(in)
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res
@@ -154,7 +154,7 @@ object DelayNWithValid{
     val pipMod = Module(new DelayNWithValid(chiselTypeOf(in.bits), n, hasInit = hasInit))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = Wire(chiselTypeOf(in))
+    val res = Wire(in)
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res

--- a/src/main/scala/utility/Hold.scala
+++ b/src/main/scala/utility/Hold.scala
@@ -133,11 +133,11 @@ object DelayNWithValid{
     (pipMod.io.out_valid, pipMod.io.out_bits)
   }
 
-  def apply[K <: Data, T <: Valid[K]](in: T, n: Int): T = {
+  def apply[T <: Valid[Data]](in: T, n: Int): T = {
     val pipMod = Module(new DelayNWithValid(in.bits.cloneType, n))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = in.cloneType
+    val res = Wire(in.cloneType)
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res
@@ -150,11 +150,11 @@ object DelayNWithValid{
     (pipMod.io.out_valid, pipMod.io.out_bits)
   }
 
-  def apply[K <: Data, T <: Valid[K]](in: T, n: Int, hasInit: Boolean): T = {
+  def apply[T <: Valid[Data]](in: T, n: Int, hasInit: Boolean): T = {
     val pipMod = Module(new DelayNWithValid(in.bits.cloneType, n, hasInit = hasInit))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = in.cloneType
+    val res = Wire(in.cloneType)
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res

--- a/src/main/scala/utility/Hold.scala
+++ b/src/main/scala/utility/Hold.scala
@@ -97,7 +97,7 @@ class DelayN[T <: Data](gen: T, n: Int) extends Module {
 
 object DelayN {
   def apply[T <: Data](in: T, n: Int): T = {
-    val delay = Module(new DelayN(in.cloneType, n))
+    val delay = Module(new DelayN(chiselTypeOf(in), n))
     delay.io.in := in
     delay.io.out
   }
@@ -127,34 +127,34 @@ class DelayNWithValid[T <: Data](gen: T, n: Int, hasInit: Boolean = true) extend
 
 object DelayNWithValid{
   def apply[T <: Data](in: T, valid: Bool, n: Int): (Bool, T) = {
-    val pipMod = Module(new DelayNWithValid(in.cloneType, n))
+    val pipMod = Module(new DelayNWithValid(chiselTypeOf(in), n))
     pipMod.io.in_valid := valid
     pipMod.io.in_bits := in
     (pipMod.io.out_valid, pipMod.io.out_bits)
   }
 
   def apply[T <: Valid[Data]](in: T, n: Int): T = {
-    val pipMod = Module(new DelayNWithValid(in.bits.cloneType, n))
+    val pipMod = Module(new DelayNWithValid(chiselTypeOf(in.bits), n))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = Wire(in.cloneType)
+    val res = Wire(chiselTypeOf(in))
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res
   }
 
   def apply[T <: Data](in: T, valid: Bool, n: Int, hasInit: Boolean): (Bool, T) = {
-    val pipMod = Module(new DelayNWithValid(in.cloneType, n, hasInit = hasInit))
+    val pipMod = Module(new DelayNWithValid(chiselTypeOf(in), n, hasInit = hasInit))
     pipMod.io.in_valid := valid
     pipMod.io.in_bits := in
     (pipMod.io.out_valid, pipMod.io.out_bits)
   }
 
   def apply[T <: Valid[Data]](in: T, n: Int, hasInit: Boolean): T = {
-    val pipMod = Module(new DelayNWithValid(in.bits.cloneType, n, hasInit = hasInit))
+    val pipMod = Module(new DelayNWithValid(chiselTypeOf(in.bits), n, hasInit = hasInit))
     pipMod.io.in_valid := in.valid
     pipMod.io.in_bits := in.bits
-    val res = Wire(in.cloneType)
+    val res = Wire(chiselTypeOf(in))
     res.valid := pipMod.io.out_valid
     res.bits := pipMod.io.out_bits
     res


### PR DESCRIPTION
1. add `GatedValidRegNext` of bool vector, `GatedValidRegNextN`, `GatedRegNext` and `GatedRegNextN`
2. fix DelayNWithValid compile bug due to no use of K and error hardware type of data