### PR TITLE
ClockGate: use `VERILATOR_LEGACY` for verilator version less than 5

### DIFF
--- a/src/main/scala/utility/ClockGate.scala
+++ b/src/main/scala/utility/ClockGate.scala
@@ -40,24 +40,16 @@ class ClockGate extends BlackBox with HasBlackBoxInline {
       |
       |  assign clk_en = E | TE;
       |
-      |`ifdef VCS
+      |`ifndef VERILATOR_LEGACY
       |  always @(CK or clk_en) begin
       |    if (CK == 1'b0)
       |      clk_en_reg <= clk_en;
       |  end
       |`else
-      |`ifdef VERILATOR_5
-      |  always @(CK or clk_en) begin
-      |    if (CK == 1'b0)
-      |      clk_en_reg <= clk_en;
+      |  always @(posedge CK) begin
+      |    clk_en_reg = clk_en;
       |  end
-      |`else
-      | always @(posedge CK) 
-      |   begin
-      |     clk_en_reg = clk_en;
-      |   end
-      |`endif // VERILATOR_5
-      |`endif // VCS
+      |`endif // VERILATOR_LEGACY
       |
       |  assign Q = CK & clk_en_reg;
       |


### PR DESCRIPTION
Previously, `ClockGate.v` is written as:

``` v
module ClockGate (
  input  wire TE,
  input  wire E,
  input  wire CK,
  output wire Q
);

  wire clk_en;
  reg  clk_en_reg;

  assign clk_en = E | TE;

`ifdef VCS
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
`ifdef VERILATOR_5
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
  // code B
 always @(posedge CK) 
   begin
     clk_en_reg = clk_en;
   end
`endif // VERILATOR_5
`endif // VCS

  assign Q = CK & clk_en_reg;

endmodule
```

Actually, only verilator 4 should use code B. All other tested platforms like verilator 5, vcs and vivado should use code A. It is better to write ClockGate as:

``` v
module ClockGate (
  input  wire TE,
  input  wire E,
  input  wire CK,
  output wire Q
);

  wire clk_en;
  reg  clk_en_reg;

  assign clk_en = E | TE;

`ifndef VERILATOR_LEGACY
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
  // code B
 always @(posedge CK) 
   begin
     clk_en_reg = clk_en;
   end
`endif // VERILATOR_LEGACY

  assign Q = CK & clk_en_reg;

endmodule
```