### PR TITLE
clock gate: add functions for duplicate regs

### DIFF
--- a/src/main/scala/utility/ClockGatedReg.scala
+++ b/src/main/scala/utility/ClockGatedReg.scala
@@ -80,6 +80,53 @@ object GatedRegNext{
   }
 }
 
+object GatedRegEnable{
+  // Vec can be judged and assigned one by one
+  def regEnableVec[T <: Data](lastVec: Vec[T], initOptVec: Option[Vec[T]], enable: Bool): Vec[T] = {
+    val nextVec = WireInit(0.U.asTypeOf(lastVec))
+    for (i <- 0 until lastVec.length) {
+      initOptVec match {
+        case Some(initVec) => nextVec(i) := RegEnable(lastVec(i), initVec(i), enable && lastVec(i).asUInt =/= nextVec(i).asUInt)
+        case None => nextVec(i) := RegEnable(lastVec(i), 0.U.asTypeOf(lastVec(i)), enable && lastVec(i).asUInt =/= nextVec(i).asUInt)
+      }
+    }
+    nextVec
+  }
+
+  // NOTICE: The larger Data width , the longger time of =/= operations, which may lead to timing violations.
+  // Callers need to consider timing requirements themselves.
+  def apply[T <: Data](last: T, initOpt: Option[T] = None, enable: Bool): T = {
+    val next = WireInit(0.U.asTypeOf(last))
+    last match {
+      case v: Vec[_] =>
+        next := regEnableVec(v.asInstanceOf[Vec[T]], initOpt.map(_.asInstanceOf[Vec[T]]), enable)
+      case _ =>
+        initOpt match {
+          case Some(init) => next := RegEnable(last, init, enable && last.asUInt =/= next.asUInt)
+          case None => next := RegEnable(last, 0.U.asTypeOf(last), enable && last.asUInt =/= next.asUInt)
+        }
+    }
+    next
+  }
+
+  def dupRegs[T <: Data](last: Vec[T], initOpt: Option[Vec[T]] = None, enable: Bool): Vec[T] = {
+    require(last.length > 0, "Input Vec must have at least one element")
+    
+    val numDup = last.length
+    val next = WireInit(0.U.asTypeOf(last))
+
+    val updateEnable = enable && last(0).asUInt =/= next(0).asUInt
+
+    for (i <- 0 until numDup) {
+      initOpt match {
+        case Some(init) => next(i) := RegEnable(last(i), init(i), updateEnable)
+        case None => next(i) := RegEnable(last(i), 0.U.asTypeOf(last(i)), updateEnable)
+      }
+    }
+    next
+  }
+}
+
 object GatedRegNextN {
   def apply[T <: Data](in: T, n: Int, initOpt: Option[T] = None): T = {
     (0 until n).foldLeft(in){
@@ -165,5 +212,48 @@ object SegmentedAddrNext {
     }
 
     seg
+  }
+  
+  def dupAddrs(addrs: Seq[UInt], segments: Seq[Int], fire: Bool, parentName: Option[String]): Seq[SegmentedAddr] = {
+    // Input wire, segmented
+    val dupSegmented = segments.zipWithIndex.map { case (segLength, idx) =>
+      addrs.map(addr => new SegmentedAddr(segments).fromAddr(addr).getAddrSegments()(idx))
+    }
+    // dupSegmented(segIdx)(dupIdx), 
+    // dupSegmented = Seq(
+    //   Seq(seg0_addr0, seg0_addr1, seg0_addr2, seg0_addr3),  // first  segment results of each addr after segmentation
+    //   Seq(seg1_addr0, seg1_addr1, seg1_addr2, seg1_addr3),  // second segment results of each addr after segmentation
+    //   Seq(seg2_addr0, seg2_addr1, seg2_addr2, seg2_addr3)   // third  segment results of each addr after segmentation
+    // )
+
+    val modified = Wire(Vec(segments.length, Bool()))
+
+    val dupSegmentedNext = segments zip dupSegmented zip modified.zipWithIndex map {
+      case ((segLength, dupSegs), (modified, segIdx)) => {
+        val nextDupSegs = dupSegs.zipWithIndex.map{ case (seg, dupIdx) =>
+          // for each seg in duplicate segs ...
+          RegEnable(seg, 0.U(segLength.W), modified && fire)
+            .suggestName(s"${parentName.getOrElse("")}_seg_${segIdx}_dup_${dupIdx}_value")
+        }
+        nextDupSegs
+      }
+    }
+
+    for (segIdx <- 0 until segments.length) {
+      modified(segIdx) := dupSegmented(segIdx)(0) =/= dupSegmentedNext(segIdx)(0)
+    }
+    modified.last := true.B // Assume lower part often changes
+
+    // dupSegmentedNext.transpose:
+    // Seq(
+    //   Seq(addr0_seg0, addr0_seg1, addr0_seg2),  // segmented result of addr(0)
+    //   Seq(addr1_seg0, addr1_seg1, addr1_seg2),  // segmented result of addr(1)
+    //   Seq(addr2_seg0, addr2_seg1, addr2_seg2),  // segmented result of addr(2)
+    //   Seq(addr3_seg0, addr3_seg1, addr3_seg2)   // segmented result of addr(3)
+    // )
+    val result = dupSegmentedNext.transpose.map { segs =>
+      new SegmentedAddr(segments).fromSegments(segs)
+    }
+    result
   }
 }


### PR DESCRIPTION
GatedRegEnable: add `enable` parameter base on GatedRegNext

GatedRegEnable.dupRegs and SegmentedAddrNext.dupAddrs: Deal with the clock gate efficiency of [duplicate regs](https://github.com/OpenXiangShan/XiangShan/commit/868d6014398e965774f26b1bf3760f47215dd641) in frontend of XiangShan.
