### PR TITLE
ChiselDB: fix char* buffer may overflow

### DIFF
--- a/src/main/scala/utility/ChiselDB.scala
+++ b/src/main/scala/utility/ChiselDB.scala
@@ -113,8 +113,8 @@ class Table[T <: Record](val envInFPGA: Boolean, val tableName: String, val hw: 
          |  if(!dump || !enable_dump_$tableName) return;
          |
          |  const char *format = "INSERT INTO $tableName(${cols.map(_.toUpperCase).mkString(",")}, STAMP, SITE) " \\
-         |                  "VALUES(${cols.map(_ => "%ld").mkString(", ")}, %ld, '%s');";
-         |  char *sql = (char *)malloc(${cols.size + 1} * sizeof(uint64_t) + (strlen(format)+strlen(site)) * sizeof(char));
+         |                  "VALUES(${cols.map(_ => "%#lx").mkString(", ")}, %#lx, '%s');";
+         |  char *sql = (char *)malloc(${(cols.size + 1) * 2} * sizeof(uint64_t) + (strlen(format)+strlen(site)) * sizeof(char));
          |  sprintf(sql,
          |    format,
          |    ${cols.mkString(",")}, stamp, site


### PR DESCRIPTION
Previous version allocates **64bits** in _char* sql_ for every item,

but such item(uint64) is printed using %ld, so it will eventually become a string of at most 20 digits(char[20]),
and that is 20 * sizeof(char) = **160 > 64**, resulting in overflow of _char* sql_

We solve this by printing with %#lx -> 0x123ABC (at most 16 digits),
and we allocate 16 * sizeof(char) = 128bits for every item