### PR TITLE
feat(LogPerfHelper): reuse LogPerfHelper if visible

### DIFF
--- a/src/main/scala/utility/LogPerfHelper.scala
+++ b/src/main/scala/utility/LogPerfHelper.scala
@@ -2,6 +2,7 @@ package utility
 
 import chisel3._
 import chisel3.util.HasBlackBoxInline
+import chisel3.reflect.DataMirror.isVisible
 
 class LogPerfIO extends Bundle {
   val timer = UInt(64.W)
@@ -36,4 +37,11 @@ class LogPerfHelper extends BlackBox with HasBlackBoxInline {
       |
       |""".stripMargin
   setInline("LogPerfHelper.v", verilog)
+}
+
+object LogPerfControl {
+  private val instances = scala.collection.mutable.ListBuffer.empty[LogPerfIO]
+  private def instantiate(): LogPerfIO = instances.addOne(WireInit(Module(new LogPerfHelper).io)).last
+
+  def apply(): LogPerfIO = instances.find(gen => isVisible(gen)).getOrElse(instantiate())
 }

--- a/src/main/scala/utility/LogUtils.scala
+++ b/src/main/scala/utility/LogUtils.scala
@@ -49,7 +49,7 @@ object XSLog {
     val enableDebug = logOpts.enableDebug && debugLevel != XSLogLevel.PERF
     val enablePerf = logOpts.enablePerf && debugLevel == XSLogLevel.PERF
     if (!logOpts.fpgaPlatform && (enableDebug || enablePerf || debugLevel == XSLogLevel.ERROR)) {
-      val ctrlInfo = ctrlInfoOpt.getOrElse(Module(new LogPerfHelper).io)
+      val ctrlInfo = ctrlInfoOpt.getOrElse(LogPerfControl())
       val logEnable = ctrlInfo.logEnable
       val logTimestamp = ctrlInfo.timer
       val check_cond = (if (debugLevel == XSLogLevel.ERROR) true.B else logEnable) && cond

--- a/src/main/scala/utility/PerfCounterUtils.scala
+++ b/src/main/scala/utility/PerfCounterUtils.scala
@@ -45,9 +45,9 @@ object XSPerfAccumulate extends HasRegularPerfName {
   def apply(perfName: String, perfCnt: UInt)(implicit p: Parameters): Unit = {
     judgeName(perfName)
     if (p(PerfCounterOptionsKey).enablePerfPrint) {
-      val helper = Module(new LogPerfHelper)
-      val perfClean = helper.io.clean
-      val perfDump = helper.io.dump
+      val helper = LogPerfControl()
+      val perfClean = helper.clean
+      val perfDump = helper.dump
 
       val counter = RegInit(0.U(64.W)).suggestName(perfName + "Counter")
       val next_counter = WireInit(0.U(64.W)).suggestName(perfName + "Next")
@@ -55,7 +55,7 @@ object XSPerfAccumulate extends HasRegularPerfName {
       counter := Mux(perfClean, 0.U, next_counter)
 
       when (perfDump) {
-        XSPerfPrint(p"$perfName, $next_counter\n")(helper.io)
+        XSPerfPrint(p"$perfName, $next_counter\n")(helper)
       }
     }
   }
@@ -78,9 +78,9 @@ object XSPerfHistogram extends HasRegularPerfName {
   (implicit p: Parameters): Unit = {
     judgeName(perfName)
     if (p(PerfCounterOptionsKey).enablePerfPrint) {
-      val helper = Module(new LogPerfHelper)
-      val perfClean = helper.io.clean
-      val perfDump = helper.io.dump
+      val helper = LogPerfControl()
+      val perfClean = helper.clean
+      val perfDump = helper.dump
 
       val sum = RegInit(0.U(64.W)).suggestName(perfName + "Sum")
       val nSamples = RegInit(0.U(64.W)).suggestName(perfName + "NSamples")
@@ -103,11 +103,11 @@ object XSPerfHistogram extends HasRegularPerfName {
       }
 
       when (perfDump) {
-        XSPerfPrint(p"${perfName}_sum, ${sum}\n")(helper.io)
-        XSPerfPrint(p"${perfName}_mean, ${sum/nSamples}\n")(helper.io)
-        XSPerfPrint(p"${perfName}_sampled, ${nSamples}\n")(helper.io)
-        XSPerfPrint(p"${perfName}_underflow, ${underflow}\n")(helper.io)
-        XSPerfPrint(p"${perfName}_overflow, ${overflow}\n")(helper.io)
+        XSPerfPrint(p"${perfName}_sum, ${sum}\n")(helper)
+        XSPerfPrint(p"${perfName}_mean, ${sum/nSamples}\n")(helper)
+        XSPerfPrint(p"${perfName}_sampled, ${nSamples}\n")(helper)
+        XSPerfPrint(p"${perfName}_underflow, ${underflow}\n")(helper)
+        XSPerfPrint(p"${perfName}_overflow, ${overflow}\n")(helper)
       }
 
       // drop each perfCnt value into a bin
@@ -142,7 +142,7 @@ object XSPerfHistogram extends HasRegularPerfName {
         }
 
         when (perfDump) {
-          XSPerfPrint(p"${histName}, $counter\n")(helper.io)
+          XSPerfPrint(p"${histName}, $counter\n")(helper)
         }
       }
     }
@@ -153,16 +153,16 @@ object XSPerfMax extends HasRegularPerfName {
   def apply(perfName: String, perfCnt: UInt, enable: Bool)(implicit p: Parameters): Unit = {
     judgeName(perfName)
     if (p(PerfCounterOptionsKey).enablePerfPrint) {
-      val helper = Module(new LogPerfHelper)
-      val perfClean = helper.io.clean
-      val perfDump = helper.io.dump
+      val helper = LogPerfControl()
+      val perfClean = helper.clean
+      val perfDump = helper.dump
 
       val max = RegInit(0.U(64.W))
       val next_max = Mux(enable && (perfCnt > max), perfCnt, max)
       max := Mux(perfClean, 0.U, next_max)
 
       when (perfDump) {
-        XSPerfPrint(p"${perfName}_max, $next_max\n")(helper.io)
+        XSPerfPrint(p"${perfName}_max, $next_max\n")(helper)
       }
     }
   }


### PR DESCRIPTION
Modified from Difftest Repo. See details in Difftest PR#261 and #309.

To avoid a large number of duplicated LogPerfHelper instantiated in same module, we allow reusing previous instances if visible.

Note instances in when scope cannot be accessed from other, such instances is not visible and cannot be reused, we will still instantiate another duplicated one.