### PR TITLE
feat(subvec): add sub vector method including remainder

### DIFF
--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -26,21 +26,21 @@ object SubVec{
     require(mod > rem)
     (0 until in.size / mod).map(i => {in(mod * i + rem)})
   }
-  def getRems[T <: Data](in: Seq[T], mod: Int): Seq[Seq[T]] = {
+  def getRem[T <: Data](in: Seq[T], mod: Int): Seq[Seq[T]] = {
     (0 until mod).map { rem => getRem(in, mod, rem) }
   }
 
-  // RemWithExpand: SubSeqWithExpand = (Seq % Modulus expanded)(Remainder)
-  def getRemWithExpand(in: Seq[Bool], mod: Int, rem: Int): Seq[Bool] = {
+  // RemWithExpansion: SubSeqWithExpansion = (Seq % Modulus expanded)(Remainder)
+  def getRemWithExpansion[T <: Data](in: Seq[T], mod: Int, rem: Int): Seq[T] = {
     require(mod > rem)
     val subSize = in.size / mod + 1
     (0 until subSize).map {i =>
       val idx = mod * i + rem
-      if (idx < in.size) in(idx) else false.B
+      if (idx < in.size) in(idx) else 0.U.asTypeOf(in(0))
     }
   }
-  def getRemWithExpands(in: Seq[Bool], mod: Int): Seq[Seq[Bool]] = {
-    (0 until mod).map { rem => getRemWithExpand(in, mod, rem) }
+  def getRemWithExpansion[T <: Data](in: Seq[T], mod: Int): Seq[Seq[T]] = {
+    (0 until mod).map { rem => getRemWithExpansion(in, mod, rem) }
   }
 
   // MaskRem: MaskSeq = RemMask & Seq(RemIdx)
@@ -51,7 +51,7 @@ object SubVec{
     (0 until in.size).map(i => { if(i % mod == rem) out(i) := in(i) else out(i) := false.B})
     out
   }
-  def getMaskRems(in: Vec[Bool], mod: Int): Vec[Vec[Bool]] = {
+  def getMaskRem(in: Vec[Bool], mod: Int): Vec[Vec[Bool]] = {
     VecInit((0 until mod).map(rem => getMaskRem(in, mod, rem)))
   }
 

--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -1,0 +1,58 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package utility
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.util.SeqToAugmentedSeq
+
+object SubVec{
+  // Rem: SubSeq = (Seq % Modulus)(Remainder)
+  // NOTE: must be divisible
+  def getRem[T <: Data](in: Seq[T], mod: Int, rem: Int): Seq[T] = {
+    require(in.size % mod == 0)
+    (0 until in.size / mod).map(i => {in(mod * i + rem)})
+  }
+  def getRems[T <: Data](in: Seq[T], mod: Int): Seq[Seq[T]] = {
+    require(in.size % mod == 0)
+    (0 until mod).map { rem => getRem(in, mod, rem) }
+  }
+
+  // RemWithExpand: SubSeqWithExpand = (Seq % Modulus expanded)(Remainder)
+  def getRemWithExpand(in: Seq[Bool], mod: Int, rem: Int): Seq[Bool] = {
+    val subSize = in.size / mod + 1
+    (0 until subSize).map {i =>
+      val idx = mod * i + rem
+      if (idx < in.size) in(idx) else false.B
+    }
+  }
+  def getRemWithExpands(in: Seq[Bool], mod: Int): Seq[Seq[Bool]] = {
+    (0 until mod).map { rem => getRemWithExpand(in, mod, rem) }
+  }
+
+  // MaskRem: SubSeq = RemMask & Seq(RemIdx)
+  // NOTE: logical size  big
+  def getMaskRem(in: Vec[Bool], mod: Int, rem: Int): Vec[Bool] = {
+    val out = WireInit(0.U.asTypeOf(in))
+    (0 until in.size).map(i => { if(i % mod == rem) out(i) := in(i) else out(i) := false.B})
+    out
+  }
+  def getMaskRems(in: Vec[Bool], mod: Int): Vec[Vec[Bool]] = {
+    VecInit((0 until mod).map(rem => getMaskRem(in, mod, rem)))
+  }
+
+}

--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
-* Copyright (c) 2020-2021 Peng Cheng Laboratory
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2024 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * XiangShan is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -17,8 +17,6 @@
 package utility
 
 import chisel3._
-import chisel3.util._
-import freechips.rocketchip.util.SeqToAugmentedSeq
 
 object SubVec{
   // Rem: SubSeq = (Seq % Modulus)(Remainder)

--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -25,15 +25,16 @@ object SubVec{
   // NOTE: must be divisible
   def getRem[T <: Data](in: Seq[T], mod: Int, rem: Int): Seq[T] = {
     require(in.size % mod == 0)
+    require(mod > rem)
     (0 until in.size / mod).map(i => {in(mod * i + rem)})
   }
   def getRems[T <: Data](in: Seq[T], mod: Int): Seq[Seq[T]] = {
-    require(in.size % mod == 0)
     (0 until mod).map { rem => getRem(in, mod, rem) }
   }
 
   // RemWithExpand: SubSeqWithExpand = (Seq % Modulus expanded)(Remainder)
   def getRemWithExpand(in: Seq[Bool], mod: Int, rem: Int): Seq[Bool] = {
+    require(mod > rem)
     val subSize = in.size / mod + 1
     (0 until subSize).map {i =>
       val idx = mod * i + rem
@@ -47,6 +48,7 @@ object SubVec{
   // MaskRem: MaskSeq = RemMask & Seq(RemIdx)
   // NOTE: logical size is big
   def getMaskRem(in: Vec[Bool], mod: Int, rem: Int): Vec[Bool] = {
+    require(mod > rem)
     val out = WireInit(0.U.asTypeOf(in))
     (0 until in.size).map(i => { if(i % mod == rem) out(i) := in(i) else out(i) := false.B})
     out

--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -45,7 +45,7 @@ object SubVec{
   }
 
   // MaskRem: SubSeq = RemMask & Seq(RemIdx)
-  // NOTE: logical size  big
+  // NOTE: logical size is big
   def getMaskRem(in: Vec[Bool], mod: Int, rem: Int): Vec[Bool] = {
     val out = WireInit(0.U.asTypeOf(in))
     (0 until in.size).map(i => { if(i % mod == rem) out(i) := in(i) else out(i) := false.B})

--- a/src/main/scala/utility/SubVec.scala
+++ b/src/main/scala/utility/SubVec.scala
@@ -44,7 +44,7 @@ object SubVec{
     (0 until mod).map { rem => getRemWithExpand(in, mod, rem) }
   }
 
-  // MaskRem: SubSeq = RemMask & Seq(RemIdx)
+  // MaskRem: MaskSeq = RemMask & Seq(RemIdx)
   // NOTE: logical size is big
   def getMaskRem(in: Vec[Bool], mod: Int, rem: Int): Vec[Bool] = {
     val out = WireInit(0.U.asTypeOf(in))


### PR DESCRIPTION
add sub vector method including remainder, which can be used to support multi-port output for queue/buffer.