### PR TITLE
fix(LogUtils): support probe subaccess data

### DIFF
--- a/src/main/scala/utility/LogUtils.scala
+++ b/src/main/scala/utility/LogUtils.scala
@@ -77,7 +77,7 @@ object XSLog {
         data ++= subdata
       }
       case y: FirrtlFormat => {
-        data += y.bits
+        data += WireInit(y.bits)
         y match {
           case Decimal(d) => fmt += "%d"
           case Hexadecimal(x) => fmt += "%x"


### PR DESCRIPTION
This change add WireInit to LogUtils' apply, converting some subacces data, like vec element with dynamic index, to data can be probed.