### PR TITLE
fix(FoldedSRAMTemplate): fix SRAM split parameters not working in FoldedSRAMTemplate

### DIFF
--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -376,12 +376,12 @@ class SplittedSRAMTemplate[T <: Data]
   val innerWidth = gen.getWidth / dataSplit
 
   val array = Seq.fill(setSplit)(Seq.fill(waySplit)(Seq.fill(dataSplit)(
-    Module(new SRAMTemplate(UInt(innerWidth.W), set, way, singlePort,
+    Module(new SRAMTemplate(UInt(innerWidth.W), innerSets, innerWays, singlePort,
     shouldReset, extraReset,
     holdRead, bypassWrite,
     useBitmask,withClockGate,
     separateGateClock, hasMbist, latency, extraHold,
-    extClockGate, suffix
+    extClockGate, Some(suffix.getOrElse(SramHelper.getSramSuffix(valName.value)))
     ))
   )))
 


### PR DESCRIPTION
When creating the SplittedSRAMTemplate class, flaws in the code related to the split parameters were overlooked. While the incorrect parameters did not affect functional correctness, they impacted SRAM size configuration.