### PR TITLE
fix(FoldSRAMTemplate): modify the assignment logic of ren_vec to avoid X-state issues.

### DIFF
--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -420,7 +420,7 @@ class SplittedSRAMTemplate[T <: Data]
   }
 
   val ren_vec_0 = VecInit((0 until setSplit).map(i => i.U === r_bankSel))
-  val ren_vec_1 = RegNext(ren_vec_0, 0.U.asTypeOf(ren_vec_0))
+  val ren_vec_1 = RegEnable(ren_vec_0, 0.U.asTypeOf(ren_vec_0), io.r.req.valid)
   val ren_vec = ren_vec_1
 
   // only one read/write


### PR DESCRIPTION
The timing of feeding a stable PC value after BPU reset differs from the reset timing of ren_vec in the SplittedSRAMTemplate. Directly updating ren_vec using the lower bits of the PC may introduce X-state propagation.