### PR TITLE
Add multiple modes for handling read-write conflicts in dual-port SRAMs

### DIFF
--- a/src/main/scala/utility/package.scala
+++ b/src/main/scala/utility/package.scala
@@ -2,6 +2,9 @@ import chisel3.Data
 
 package object utility {
   @deprecated
+  val SRAMConflictBehavior = _root_.utility.sram.SRAMConflictBehavior
+  type SRAMConflictBehavior = SRAMConflictBehavior.SRAMConflictBehavior
+  @deprecated
   type SRAMTemplate[T <: Data] = _root_.utility.sram.SRAMTemplate[T]
   @deprecated
   type FoldedSRAMTemplate[T <: Data] = _root_.utility.sram.FoldedSRAMTemplate[T]

--- a/src/main/scala/utility/package.scala
+++ b/src/main/scala/utility/package.scala
@@ -2,9 +2,6 @@ import chisel3.Data
 
 package object utility {
   @deprecated
-  val SRAMConflictBehavior = _root_.utility.sram.SRAMConflictBehavior
-  type SRAMConflictBehavior = SRAMConflictBehavior.SRAMConflictBehavior
-  @deprecated
   type SRAMTemplate[T <: Data] = _root_.utility.sram.SRAMTemplate[T]
   @deprecated
   type FoldedSRAMTemplate[T <: Data] = _root_.utility.sram.FoldedSRAMTemplate[T]

--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -16,6 +16,7 @@
 
 package utility.sram
 
+import scala.util.Random
 import chisel3._
 import chisel3.util._
 import sourcecode.FullName
@@ -379,7 +380,11 @@ class SRAMTemplate[T <: Data](
   private val raw_rdata = ramRdata.asTypeOf(Vec(way, wordType))
   require(wdata.getWidth == ramRdata.getWidth)
 
-  val randomData = VecInit(Seq.tabulate(way)(i => LFSR64(seed=Some(i)).asTypeOf(wordType)))
+  val randomData = VecInit(Seq.tabulate(way) { i =>
+    var seed = new Random(i).nextLong()
+    if (seed < 0) seed = -seed
+    LFSR64(increment=io.r.req.valid, seed=Some(seed)).asTypeOf(wordType)
+  })
 
   // conflict handling for dual-port SRAMs
   val conflictStallRead = WireInit(false.B)

--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -411,8 +411,6 @@ class SRAMTemplate[T <: Data](
       conflictBufferValid := conflictValidS1
       conflictBufferCanWrite := true.B
       conflictStallRead := conflictBufferValid
-      // Bypass is not needed since read stall is asserted when buffer is valid
-      bypassEnable := false.B
       conflictStallWrite := conflictBufferValid
     }
     case BufferWriteLossy => {

--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -395,6 +395,7 @@ class SRAMTemplate[T <: Data](
     case CorruptReadWay => {
       bypassData := randomData
     }
+    case BypassWrite => // Handled elsewhere
     case BufferWrite => {
       // Stall reads when the buffer is valid, which guarantees it can be written to the RAM immediately
       conflictBufferValid := conflictValidS1

--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -469,7 +469,7 @@ class FoldedSRAMTemplate[T <: Data](
   shouldReset: Boolean = false, extraReset: Boolean = false,
   holdRead: Boolean = false, singlePort: Boolean = false,
   conflictBehavior: SRAMConflictBehavior = CorruptReadWay, useBitmask: Boolean = false,
-  withClockGate: Boolean = false, avoidSameAddr: Boolean = false,
+  withClockGate: Boolean = false,
   separateGateClock: Boolean = false, // no effect, only supports independent RW cg, only for API compatibility
   hasMbist: Boolean = false, latency: Int = 1, suffix: Option[String] = None
 )(implicit valName: sourcecode.FullName) extends Module {
@@ -507,69 +507,22 @@ class FoldedSRAMTemplate[T <: Data](
   array.io.r.req.valid := ren
   array.io.r.req.bits.setIdx := raddr
 
-  //Double port read and write to the same address to avoid
-  val w_req      = io.w.req.valid
-  val w_data     = io.w.req.bits.data
-  val w_addr     = io.w.req.bits.setIdx >> log2Ceil(width)
-  val w_widthIdx = if (width != 1) io.w.req.bits.setIdx(log2Ceil(width)-1, 0) else 0.U
-  val w_waymask  = if(way > 1 ) io.w.req.bits.waymask.get else 0.U
-
-  val conflict_valid    = WireInit(false.B)
-  val conflict_addr     = WireInit(0.U.asTypeOf(w_addr))
-  val conflict_data     = WireInit(0.U.asTypeOf(w_data))
-  val conflict_widthIdx = WireInit(0.U.asTypeOf(w_widthIdx))
-  val conflict_waymask  = WireInit(0.U.asTypeOf(w_waymask))
-
-  val write_conflict    = w_req && ren && w_addr === raddr
-  val can_write         = conflict_valid && (conflict_addr =/= raddr || !ren)
-  val use_conflict_data = conflict_valid && conflict_addr === RegEnable(raddr, io.r.req.valid) && conflict_widthIdx === ridx
-
-  if (!singlePort && avoidSameAddr) {
-    //Cache write port data and wait for addresses to not conflict
-    val b_valid    = RegInit(false.B)
-    val b_addr     = RegInit(0.U.asTypeOf(w_addr))
-    val b_data     = RegInit(0.U.asTypeOf(w_data))
-    val b_widthIdx = RegInit(0.U.asTypeOf(w_widthIdx))
-    val b_waymask  = RegInit(0.U.asTypeOf(w_waymask))
-    when(write_conflict) {
-      b_valid    := true.B
-      b_addr     := w_addr
-      b_data     := w_data
-      b_widthIdx := w_widthIdx
-      b_waymask  := w_waymask
-    }
-    when(can_write) {
-      b_valid := false.B
-    }
-    conflict_valid    := b_valid
-    conflict_addr     := b_addr
-    conflict_data     := b_data
-    conflict_widthIdx := b_widthIdx
-    conflict_waymask  := b_waymask
-  }
-
-  val resp_data = WireInit(0.U.asTypeOf(io.r.resp.data))
   val rdata = array.io.r.resp.data
   for (w <- 0 until way) {
     val wayData = VecInit(rdata.indices.filter(_ % way == w).map(rdata(_)))
     val holdRidx = HoldUnless(ridx, GatedValidRegNext(io.r.req.valid))
     val realRidx = if (holdRead) holdRidx else ridx
-    resp_data(w) := Mux1H(UIntToOH(realRidx, width), wayData)
+    io.r.resp.data(w) := Mux1H(UIntToOH(realRidx, width), wayData)
   }
-  io.r.resp.data := Mux(use_conflict_data, conflict_data, resp_data)
 
-  val wen = if (!singlePort && avoidSameAddr) (io.w.req.valid && !write_conflict) || can_write else w_req
-  val waddr = if (!singlePort && avoidSameAddr) Mux(conflict_valid, conflict_addr, w_addr) else w_addr
-  val wdata = VecInit(Seq.fill(width)(
-    if (!singlePort && avoidSameAddr) Mux(conflict_valid, conflict_data, w_data)
-    else w_data
-  ).flatten)
-  val widthIdx = if (!singlePort && avoidSameAddr) Mux(conflict_valid, conflict_widthIdx, w_widthIdx) else w_widthIdx
-  val waymask = if (!singlePort && avoidSameAddr) Mux(conflict_valid, conflict_waymask, w_waymask) else w_waymask
+  val wen = io.w.req.valid
+  val wdata = VecInit(Seq.fill(width)(io.w.req.bits.data).flatten)
+  val waddr = io.w.req.bits.setIdx >> log2Ceil(width)
+  val widthIdx = if (width != 1) io.w.req.bits.setIdx(log2Ceil(width)-1, 0) else 0.U
   val wmask = (width, way) match {
     case (1, 1) => 1.U(1.W)
     case (x, 1) => UIntToOH(widthIdx)
-    case _      => VecInit(Seq.tabulate(width*way)(n => (n / way).U === widthIdx && waymask(n % way))).asUInt
+    case _      => VecInit(Seq.tabulate(width*way)(n => (n / way).U === widthIdx && io.w.req.bits.waymask.get(n % way))).asUInt
   }
   require(wmask.getWidth == way*width)
 

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -74,7 +74,9 @@ abstract class SRAMSpec extends AnyFlatSpec with Matchers {
     }
 
     resetInputs
+    dut.reset.poke(true.B)
     step
+    dut.reset.poke(false.B)
   }
 
   def read(setIdx: UInt, waitReady: Boolean = true)(implicit dut: DUT): Unit = {

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -273,7 +273,7 @@ class SinglePortSRAMSpec extends CommonSRAMSpec {
     singlePort = true,
     holdRead = false,
     shouldReset = false,
-    conflictBehavior = CorruptReadWay
+    conflictBehavior = DefaultBehavior
   )
 
   it should "reject read during write" in {
@@ -294,7 +294,7 @@ class FoldedSinglePortSRAMSpec extends SinglePortSRAMSpec {
     singlePort = true,
     holdRead = false,
     shouldReset = false,
-    conflictBehavior = CorruptReadWay,
+    conflictBehavior = DefaultBehavior,
     foldedWidth = 2
   )
 }

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -1,0 +1,238 @@
+package utility.sram
+
+import chisel3._
+import chisel3.simulator.EphemeralSimulator._
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should.Matchers
+
+abstract class SRAMSpec extends AnyFlatSpec with Matchers {
+  def stepUntilTimeoutCycles = 256
+
+  case class DUTParams(
+    entryType: UInt,
+    sets: Int,
+    ways: Int,
+    singlePort: Boolean,
+    holdRead: Boolean,
+    shouldReset: Boolean
+  )
+
+  // extend the module to provide access to parameters within tests
+  class DUT(val params: DUTParams, suffix: String) extends SRAMTemplate(
+    gen=params.entryType,
+    set=params.sets,
+    way=params.ways,
+    singlePort=params.singlePort,
+    holdRead=params.holdRead,
+    shouldReset=params.shouldReset,
+    suffix=Some(suffix)
+  )
+
+  // FIXME: debug why errors occur if we re-use the same suffix in multiple tests (see below)
+  // chisel3.package$ChiselException: Imported Definition information not found for sram_array_1p8x32m8s1h0l1_dut - possibly forgot to add ImportDefinition annotation?
+  // at ... ()
+  // at utility.sram.SramProto$.$anonfun$apply$3(SramProto.scala:226)
+  // at chisel3.internal.plugin.package$.autoNameRecursively(package.scala:33)
+  // at utility.sram.SramProto$.apply(SramProto.scala:226)
+  // at utility.sram.SramHelper$.genRam(SramHelper.scala:145)
+  // at utility.sram.SRAMTemplate.$anonfun$x$8$1(SRAMTemplate.scala:247)
+  // at chisel3.internal.plugin.package$.autoNameRecursivelyProduct(package.scala:48)
+  // at utility.sram.SRAMTemplate.<init>(SRAMTemplate.scala:234)
+  var dutCnt = 0
+  def makeDut(params: DUTParams) = {
+    val dut = new DUT(params, "dut" + dutCnt)
+    dutCnt += 1
+    dut
+  }
+
+  def resetInputs(implicit dut: DUT): Unit = {
+    dut.io.r.req.valid.poke(false.B)
+    dut.io.w.req.valid.poke(false.B)
+  }
+
+  def step(implicit dut: DUT): Unit = {
+    dut.clock.step()
+    resetInputs
+  }
+
+  def stepUntil(expr: => Boolean, timeout: Int = stepUntilTimeoutCycles)(implicit dut: DUT): Unit = {
+    var stepCycles = 0
+    while (!expr) {
+      assert(stepCycles < timeout)
+      stepCycles += 1
+      dut.clock.step()
+    }
+  }
+
+  def initialize(implicit dut: DUT): Unit = {
+    val writeReq = dut.io.w.req
+    if (writeReq.bits.waymask.isDefined) {
+      require(writeReq.bits.waymask.get.getWidth == writeReq.bits.data.length)
+    }
+
+    resetInputs
+    step
+  }
+
+  def read(setIdx: UInt)(implicit dut: DUT): Unit = {
+    val req = dut.io.r.req
+    req.valid.poke(true.B)
+    req.bits.setIdx.poke(setIdx)
+
+    stepUntil {req.ready.peek().litToBoolean}
+  }
+
+  def getReadResult(implicit dut: DUT): Seq[UInt] = dut.io.r.resp.data.map(_.peek())
+
+  def readResultExpect(values: Seq[UInt], waymask: Option[UInt] = None)(implicit dut: DUT): Unit = {
+    val resp = dut.io.r.resp
+
+    require(values.length == resp.data.length)
+    if (waymask.isDefined) {
+      require(waymask.get.getWidth == resp.data.length)
+    }
+
+    val waymaskOrAll = waymask.getOrElse(-1.S(values.length.W).asUInt)
+    (resp.data zip values zip waymaskOrAll.asBools) map {
+      case ((actual, expected), mask) => if (mask.litToBoolean) actual.expect(expected)
+    }
+  }
+
+  def readThenExpect(setIdx: UInt, values: Seq[UInt], waymask: Option[UInt] = None)(implicit dut: DUT): Unit = {
+    read(setIdx)
+    step
+    readResultExpect(values, waymask)
+  }
+
+  def readThenGet(setIdx: UInt)(implicit dut: DUT): Seq[UInt] = {
+    read(setIdx)
+    step
+    getReadResult
+  }
+
+  def write(setIdx: UInt, values: Seq[UInt], waymask: Option[UInt] = None)(implicit dut: DUT): Unit = {
+    val req = dut.io.w.req
+
+    require(values.length == req.bits.data.length)
+    if (waymask.isDefined) {
+      require(req.bits.waymask.isDefined)
+      require(waymask.get.getWidth == req.bits.data.length)
+    }
+
+    val waymaskOrAll = waymask.getOrElse(-1.S(values.length.W).asUInt)
+    req.valid.poke(true.B)
+    req.bits.setIdx.poke(setIdx)
+    req.bits.waymask.foreach(_.poke(waymaskOrAll))
+
+    (req.bits.data zip values) map {
+      case (input, value) => input.poke(value)
+    }
+
+    stepUntil {req.ready.peek().litToBoolean}
+  }
+
+  def writeStep(setIdx: UInt, values: Seq[UInt], waymask: Option[UInt] = None)(implicit dut: DUT): Unit = {
+    write(setIdx, values, waymask)
+    step
+  }
+
+  def withDut(params: DUTParams, expr: DUT => Unit): Unit = {
+    simulate(makeDut(params)) { dut =>
+      initialize(dut)
+      expr(dut)
+    }
+  }
+}
+
+class SinglePortSRAMSpec extends SRAMSpec {
+  val defaultParams = DUTParams(
+    entryType = UInt(8.W),
+    sets = 8,
+    ways = 4,
+    singlePort = true,
+    holdRead = false,
+    shouldReset = false
+  )
+
+  def withDut(expr: DUT => Unit): Unit = withDut(defaultParams, expr)
+
+  behavior of "single-port SRAM"
+
+  it should "reject read during write" in {
+    withDut { implicit dut =>
+      write(0.U, Seq.fill(dut.params.ways)(0.U))
+      dut.io.r.req.ready.expect(false.B)
+    }
+  }
+
+  it should "return written value for write then read" in {
+    withDut { implicit dut =>
+      for (set <- 0 until dut.params.sets) {
+        val data = Seq.fill(dut.params.ways)(set.U)
+        writeStep(set.U, data)
+        step
+        readThenExpect(set.U, data)
+      }
+    }
+  }
+
+  it should "only write to ways with write mask enabled" in {
+    withDut { implicit dut =>
+      val ways = dut.params.ways
+      val dataA = Seq.fill(ways)(3.U)
+      val dataB = Seq.fill(ways)(6.U)
+      writeStep(0.U, dataA)
+      step
+      writeStep(0.U, dataB, Some(1.U(ways.W)))
+      step
+      val dataC = dataB.take(1) ++ dataA.take(ways - 1)
+      readThenExpect(0.U, dataC)
+    }
+  }
+
+  it should "hold read value when holdRead is true" in {
+    val holdParams = defaultParams.copy(holdRead = true)
+    withDut(holdParams, implicit dut => {
+      val dataA = Seq.fill(dut.params.ways)(3.U)
+      val dataB = Seq.fill(dut.params.ways)(6.U)
+      writeStep(0.U, dataA)
+      readThenExpect(0.U, dataA)
+      step
+      readResultExpect(dataA)
+      step
+      write(0.U, dataB)
+      readResultExpect(dataA)
+      step
+      readResultExpect(dataA)
+    })
+  }
+
+  it should "return random value when holdRead is false" in {
+    withDut { implicit dut =>
+      val data = Seq.fill(dut.params.ways)(3.U)
+      writeStep(0.U, data)
+      readThenExpect(0.U, data)
+      step
+      val resultA = getReadResult.map(_.litValue)
+      step
+      val resultB = getReadResult.map(_.litValue)
+      assert(resultA != resultB)
+    }
+  }
+
+  it should "contain all zero after reset when shouldReset is true" in {
+    val resetParams = defaultParams.copy(shouldReset = true)
+    withDut(resetParams, implicit dut => {
+      for (set <- 0 until dut.params.sets) {
+        readThenExpect(set.U, Seq.fill(dut.params.ways)(0.U))
+      }
+    })
+  }
+
+  it should "contain random values after reset when shouldReset is false" in {
+    withDut { implicit dut =>
+      val data: Seq[Seq[BigInt]] = (0 to 3).map(set => readThenGet(set.U).map(_.litValue))
+      assert(!data.forall(_ == data(0)))
+    }
+  }
+}

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -343,10 +343,11 @@ class DualPortSRAMSpec extends CommonSRAMSpec {
 
   it should "accept concurrent read and write at different indexes" in {
     // test for all values of conflictBehavior
+    // addresses should be far enough apart to map to different indexes in the folded version too
     SRAMConflictBehavior.values.foreach { conflictBehavior =>
       withBehavior(conflictBehavior, { implicit dut =>
         read(0.U)
-        write(1.U, Seq.fill(dut.params.ways)(0.U))
+        write(4.U, Seq.fill(dut.params.ways)(0.U))
         dut.r.req.ready.expect(true.B)
         dut.w.req.ready.expect(true.B)
       })
@@ -508,8 +509,8 @@ class DualPortSRAMSpec extends CommonSRAMSpec {
       step
 
       val writeDataB = Seq.fill(dut.params.ways)(2.U)
-      read(1.U)
-      writeStep(1.U, writeDataB)
+      read(4.U)
+      writeStep(4.U, writeDataB)
 
       val writeDataC = Seq.fill(dut.params.ways)(3.U)
       writeStep(0.U, writeDataC, Some("b0110".U(dut.params.ways.W)))
@@ -544,18 +545,18 @@ class DualPortSRAMSpec extends CommonSRAMSpec {
       val writeDataA = Seq.fill(dut.params.ways)(1.U)
       val writeDataB = Seq.fill(dut.params.ways)(2.U)
       writeStep(0.U, writeDataA)
-      writeStep(1.U, writeDataB)
+      writeStep(4.U, writeDataB)
 
       val writeDataC = Seq.fill(dut.params.ways)(3.U)
       read(0.U)
       writeStep(0.U, writeDataC, Some("b0110".U(dut.params.ways.W)))
 
       val writeDataD = Seq.fill(dut.params.ways)(4.U)
-      read(1.U)
-      writeStep(1.U, writeDataD, Some("b1010".U(dut.params.ways.W)))
+      read(4.U)
+      writeStep(4.U, writeDataD, Some("b1010".U(dut.params.ways.W)))
 
       val readDataA = readThenGet(0.U)
-      val readDataB = readThenGet(1.U)
+      val readDataB = readThenGet(4.U)
       assert(readDataA == Seq(1, 3, 3, 1))
       assert(readDataB == Seq(2, 4, 2, 4))
     })

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -279,7 +279,7 @@ class DualPortSRAMSpec extends CommonSRAMSpec("dual-port SRAM") {
 
       val writeDataB = Seq.fill(dut.params.ways)(2.U)
       read(0.U)
-      writeStep(0.U, writeDataA, Some("b0110".U(dut.params.ways.W)))
+      writeStep(0.U, writeDataB, Some("b0110".U(dut.params.ways.W)))
       val readData = getReadResult
 
       assert(readData == Seq(1, 2, 2, 1))
@@ -383,7 +383,7 @@ class DualPortSRAMSpec extends CommonSRAMSpec("dual-port SRAM") {
 
       val writeDataB = Seq.fill(dut.params.ways)(2.U)
       read(0.U)
-      writeStep(0.U, writeDataA, Some("b0110".U(dut.params.ways.W)))
+      writeStep(0.U, writeDataB, Some("b0110".U(dut.params.ways.W)))
       step
 
       val readData = readThenGet(0.U)
@@ -432,7 +432,7 @@ class DualPortSRAMSpec extends CommonSRAMSpec("dual-port SRAM") {
 
       val writeDataB = Seq.fill(dut.params.ways)(2.U)
       read(0.U)
-      writeStep(0.U, writeDataA, Some("b0110".U(dut.params.ways.W)))
+      writeStep(0.U, writeDataB, Some("b0110".U(dut.params.ways.W)))
 
       readThenExpect(0.U, Seq(1.U, 2.U, 2.U, 1.U))
     })
@@ -499,10 +499,10 @@ class DualPortSRAMSpec extends CommonSRAMSpec("dual-port SRAM") {
       read(1.U)
       writeStep(1.U, writeDataD, Some("b1010".U(dut.params.ways.W)))
 
-      val readDataA = Seq(1.U, 3.U, 3.U, 1.U)
-      val readDataB = Seq(4.U, 2.U, 4.U, 2.U)
-      readThenExpect(0.U, readDataA)
-      readThenExpect(1.U, readDataB)
+      val readDataA = readThenGet(0.U)
+      val readDataB = readThenGet(1.U)
+      assert(readDataA == Seq(1, 3, 3, 1))
+      assert(readDataB == Seq(2, 4, 2, 4))
     })
   }
 

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -197,18 +197,19 @@ abstract class CommonSRAMSpec(readableName: String) extends SRAMSpec {
     })
   }
 
-  it should "return random value when holdRead is false" in {
-    withDut { implicit dut =>
-      val data = Seq.fill(dut.params.ways)(3.U)
-      writeStep(0.U, data)
-      readThenExpect(0.U, data)
-      step
-      val resultA = getReadResult
-      step
-      val resultB = getReadResult
-      assert(resultA != resultB)
-    }
-  }
+  // There is no way currently to enable randomization through svsim interface
+  // it should "return random value when holdRead is false" in {
+  //   withDut { implicit dut =>
+  //     val data = Seq.fill(dut.params.ways)(3.U)
+  //     writeStep(0.U, data)
+  //     readThenExpect(0.U, data)
+  //     step
+  //     val resultA = getReadResult
+  //     step
+  //     val resultB = getReadResult
+  //     assert(resultA != resultB)
+  //   }
+  // }
 
   it should "contain all zero after reset when shouldReset is true" in {
     val resetParams = defaultParams.copy(shouldReset = true)
@@ -219,12 +220,13 @@ abstract class CommonSRAMSpec(readableName: String) extends SRAMSpec {
     })
   }
 
-  it should "contain random values after reset when shouldReset is false" in {
-    withDut { implicit dut =>
-      val data: Seq[Seq[BigInt]] = (0 to 3).map(set => readThenGet(set.U))
-      assert(!data.forall(_ == data(0)))
-    }
-  }
+  // There is no way currently to enable randomization through svsim interface
+  // it should "contain random values after reset when shouldReset is false" in {
+  //   withDut { implicit dut =>
+  //     val data: Seq[Seq[BigInt]] = (0 to 3).map(set => readThenGet(set.U))
+  //     assert(!data.forall(_ == data(0)))
+  //   }
+  // }
 }
 
 class SinglePortSRAMSpec extends CommonSRAMSpec("single-port SRAM") {


### PR DESCRIPTION
Hello, this change set adds a new option to the dual-port SRAM template called conflictBehavior, which determines what happens when there is a read-write conflict (a simultaneous read and write to the same index). This was implemented following the discussion in OpenXiangShan/XiangShan#4242.

Background: The behavior of SRAM macros during a read-write conflict varies. In the best case, the macro just corrupts the read result for the ways that were written. In the worst case, conflicts are a DRC violation and we must ensure they never occur. Either way, additional logic is often needed to handle conflicts, which changes based on the behavior of the macro, and the desired behavior of the interface. Since SRAMs are used many times in different parts of the design, it's best to put this additional logic inside of the template with the macro. Also, since SRAM accesses are often timing- and performance-critical, the logic should be configurable, so that cost is not paid when not needed.

To support this, the conflictBehavior accepts one of the following values to set the behavior:
- DefaultBehavior:
The default when the parameter is not specified, equivalent to CorruptReadWay. (could make it configurable via Parameters system?)
- CorruptRead:
The macro allows conflicts, but the read result is corrupted.
- CorruptReadWay:
The macro allows conflicts, but the read result is corrupted for the write ways.
- BypassWrite:
The macro allows conflicts, but the read result is corrupted for the write ways. The additional logic bypasses the write value, so that the final read result is fully valid.
- BufferWrite:
The macro does not allow conflicts. When a conflict occurs on the interface, the additional logic buffers the write until the next cycle, stalling any read or write on the interface in that cycle.
- BufferWriteLossy:
The macro does not allow conflicts. When a conflict occurs on the interface, the addtional logic buffers the write until it will not cause a conflict (may be many cycles). It is called "Lossy" because when a second conflict occurs while the buffer is valid, the write of the first conflict is lost. (This is the option most similar to the old conflict handling logic in SC and FoldedSRAMTemplate.)
- BufferWriteLossyFast:
This is similar to BufferWriteLossy, but tries to give better timing by allowing loss of the write under more conditions.
- StallWrite:
The macro does not allow conflicts. When a conflict occurs on the interface, the write is stalled.
- StallRead:
The macro does not allow conflicts. When a conflict occurs on the interface, the read is stalled.

I also added a small testbench with some directed tests to check that the logic is working as expected in each of these modes. The testbench is based on ScalaTest and EphemeralSimulator from Chisel 6. (Since the Chisel version in the Utility repo is still Chisel 3, I have been running it from the XiangShan repo using "mill utility.test".) I think EphemeralSimulator is not good for this purpose (for example, there is no easy way to capture a waveform), so if there is a different framework that the tests can use, it should be considered.

Finally, I kept the bypassWrite parameter to the SRAMTemplate for backward compability, but eventually it should be replaced with the new conflictBehavior parameter. When bypassWrite = true, it is the same as conflictBehavior = BypassWrite.

Thanks, Sam