### PR TITLE
Add runtime assertion to ensure read-write conflicts do not reach the SRAM macro in modes that do not allow it

### DIFF
--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -125,19 +125,24 @@ class SRAMWriteBus[T <: Data](
 
 /** Describes the behavior of a dual-port SRAM when there is a simultaneous read and write to the same index. */
 object SRAMConflictBehavior extends Enumeration {
+  // based on example given in Enumeration documentation
+  protected case class BehaviorVal(macroAllowsConflict: Boolean) extends super.Val
+  import scala.language.implicitConversions
+  implicit def valueToBehaviorVal(x: Value): BehaviorVal = x.asInstanceOf[BehaviorVal]
+
   type SRAMConflictBehavior = Value
 
   /** Allow read-write conflicts, but all read data is corrupt. */
-  val CorruptRead = Value
+  val CorruptRead = BehaviorVal(true)
 
   /** Allow read-write conflicts, but read data is corrupt for ways that were written to. */
-  val CorruptReadWay = Value
+  val CorruptReadWay = BehaviorVal(true)
 
   /** Allow read-write conflicts, and bypass write data to read data. This assumes the underlying macro supports
     * read-write conflicts and behaves like CorruptReadWay, since otherwise we cannot recover read data for ways that
     * were not written to.
     */
-  val BypassWrite = Value
+  val BypassWrite = BehaviorVal(true)
 
   /** Allow read-write conflicts, but the underlying macro does not support it. On a conflict, save write data into a
     * single-entry buffer. In the following cycle, stall external reads and writes, and write the buffer contents to the
@@ -145,7 +150,7 @@ object SRAMConflictBehavior extends Enumeration {
     *
     * This option requires connected logic to support read and write stalls.
     */
-  val BufferWrite = Value
+  val BufferWrite = BehaviorVal(false)
 
   /** Allow read-write conflicts, but the underlying macro does not support it. On a conflict, save the write data into a
     * single-entry buffer. The buffer contents stay valid until they can be written to the RAM without conflicting with
@@ -154,19 +159,19 @@ object SRAMConflictBehavior extends Enumeration {
     *
     * This approach has worse timing than BufferWrite, but does not require connected logic to support read and write stalls.
     */
-  val BufferWriteLossy = Value
+  val BufferWriteLossy = BehaviorVal(false)
 
   /** The same as BufferWriteLossy, but tries to improve timing by allowing more frequent loss of buffer contents. */
-  val BufferWriteLossyFast = Value
+  val BufferWriteLossyFast = BehaviorVal(false)
 
   /** Do not allow read-write conflicts. Stall the write by de-asserting the ready signal on the write port. */
-  val StallWrite = Value
+  val StallWrite = BehaviorVal(false)
 
   /** Do not allow read-write conflicts. Stall the read by de-asserting the ready signal on the read port. */
-  val StallRead = Value
+  val StallRead = BehaviorVal(false)
 
   /** Default value when parameter is not specified. */
-  val DefaultBehavior = Value
+  val DefaultBehavior = CorruptReadWay
 }
 import SRAMConflictBehavior._
 
@@ -221,10 +226,12 @@ class SRAMTemplate[T <: Data](
   })
 
   require(latency >= 1)
+
   // conflictBehavior is only meaningful for dual-port RAMs
   require(!(singlePort && conflictBehavior != DefaultBehavior))
   // bypassWrite is for backward compatibility, cannot use at the same time as conflictBehavior
   require(!(bypassWrite && conflictBehavior != DefaultBehavior))
+  val finalConflictBehavior = if (bypassWrite) BypassWrite else conflictBehavior
 
   val extra_reset = if (extraReset) Some(IO(Input(Bool()))) else None
 
@@ -357,7 +364,8 @@ class SRAMTemplate[T <: Data](
   }
 
   private val ramRdata = SramProto.read(array, singlePort, ramRaddr, ramRen)
-  when(ramWen && !brcBd.mbist.ram_hold) {
+  private val finalRamWen = ramWen && !brcBd.mbist.ram_hold
+  when(finalRamWen) {
     SramProto.write(array, singlePort, ramWaddr, ramWdata, ramWmask)
   }
 
@@ -389,6 +397,15 @@ class SRAMTemplate[T <: Data](
     cg.E := wckEn
   })
 
+  if (!singlePort && !finalConflictBehavior.macroAllowsConflict) {
+    // normally, the conflict handling logic is not triggered if the write mask is all zeroes
+    // but to be conservative, still treat that case as a conflict here
+    assert(
+      !(rckEn && wckEn && ramRen && finalRamWen && ramRaddr === ramWaddr),
+      "A read-write conflict occurred on an SRAM that does not allow it (index=0x%x)",
+      ramRaddr)
+  }
+
   private val raw_rdata = ramRdata.asTypeOf(Vec(way, wordType))
   require(wdata.getWidth == ramRdata.getWidth)
 
@@ -405,13 +422,12 @@ class SRAMTemplate[T <: Data](
   val bypassMask = WireInit(conflictWmaskS1)
   val bypassData = WireInit(conflictWdataS1)
 
-  val finalConflictBehavior = if (bypassWrite) BypassWrite else conflictBehavior
   finalConflictBehavior match {
     case CorruptRead => {
       bypassMask := Fill(way, 1.U(1.W))
       bypassData := randomData
     }
-    case CorruptReadWay | DefaultBehavior => {
+    case CorruptReadWay => {
       bypassData := randomData
     }
     case BypassWrite => // Handled elsewhere

--- a/src/main/scala/utility/sram/SRAMTemplate.scala
+++ b/src/main/scala/utility/sram/SRAMTemplate.scala
@@ -144,6 +144,9 @@ object SRAMConflictBehavior extends Enumeration {
     */
   val BypassWrite = BehaviorVal(true)
 
+  /** Read-write conflicts should not occur. If one occurs, it will trigger an assertion failure. */
+  val AssertionFail = BehaviorVal(false)
+
   /** Allow read-write conflicts, but the underlying macro does not support it. On a conflict, save write data into a
     * single-entry buffer. In the following cycle, stall external reads and writes, and write the buffer contents to the
     * RAM.
@@ -431,6 +434,9 @@ class SRAMTemplate[T <: Data](
       bypassData := randomData
     }
     case BypassWrite => // Handled elsewhere
+    case AssertionFail => {
+      bypassEnable := false.B
+    }
     case BufferWrite => {
       conflictInhibitWrite := conflictValidS0
       // Stall reads and writes when the buffer is valid, which guarantees it can be written to the RAM immediately

--- a/src/test/scala/utility/TestSRAMTemplate.scala
+++ b/src/test/scala/utility/TestSRAMTemplate.scala
@@ -2,6 +2,7 @@ package utility.sram
 
 import chisel3._
 import chisel3.simulator.EphemeralSimulator._
+import svsim.Simulation
 import org.scalatest.flatspec._
 import org.scalatest.matchers.should.Matchers
 import SRAMConflictBehavior._
@@ -404,6 +405,18 @@ class DualPortSRAMSpec extends CommonSRAMSpec {
 
   it should "(BypassWrite) return new value for written ways and old value for other ways during read-write conflict" in {
     testBypass(BypassWrite)
+  }
+
+  it should "(AssertionFail) trigger an assertion failure during concurrent read and write at the same index" in {
+    val thrown = intercept[Exception] {
+      withBehavior(AssertionFail, { implicit dut =>
+        read(0.U)
+        write(0.U, Seq.fill(dut.params.ways)(0.U))
+        step
+      })
+    }
+    // no way to directly check for an assertion failure with svsim, this will have to suffice
+    assert(thrown eq Simulation.UnexpectedEndOfMessages)
   }
 
   it should "(BufferWrite) accept concurrent read and write at the same index" in {


### PR DESCRIPTION
Hello,

This pull request is a small addition to the feature added in #110. It adds the following:
1. A new conflictBehavior setting called AssertionFail. With this setting there is no additional logic generated in the SRAM wrapper, however it is still assumed that the SRAM macro does not allow conflicts. Conflicts must be prevented through the external logic driving the interface. This is checked by the next change:
2. For all conflictBehavior settings indicating that the SRAM macro does not allow conflicts, an assertion is generated which will fail if a conflict occurs at the macro interface.

After making these changes I re-ran microbench and coremark, the cycle counts were identical and the assertion did not fail. I also added a test to the utility test suite, which checks that the assertion does fail when the conflictBehavior is set to AssertionFail and a conflict is driven on the interface.

Apologies for the delay in completing this change. It is ready for review.

Thanks, Sam