### PR TITLE
fix(ChiselDB): ignore zero width ports

### DIFF
--- a/src/main/scala/utility/ChiselDB.scala
+++ b/src/main/scala/utility/ChiselDB.scala
@@ -65,7 +65,9 @@ trait HasTableUtils {
 
         val ranges = split_ui(ui.getWidth)
         val refPort = RefPort("data_" + prefix, ui.getWidth)
-        if (ranges.size == 1) {
+        if (ui.getWidth == 0) {
+          List()
+        } else if (ranges.size == 1) {
           List(Column(prefix, refPort, refPort.ref))
         } else {
           ranges.zipWithIndex


### PR DESCRIPTION
Chisel currently allows zero width signals / ports and just ignores them when emitting verilogs.

For example, in XiangShan code base, rob.io.wb may contain EXU bundle with zero width pdest port. If tracing wb bundle blindly, ChiselDB will emit a `[-1:0]` port definition and raise missing pin warning on instanciation and the emu build will fail.