### PR TITLE
feat(LogUtils): add XSAssert

### DIFF
--- a/src/main/scala/utility/Compatibility.scala
+++ b/src/main/scala/utility/Compatibility.scala
@@ -9,5 +9,6 @@ package chisel3 {
 
     // Return the internal implicit whenContext
     def currentWhen: Option[WhenContext] = Builder.whenStack.headOption
+    def currentWhenCond: Bool = if(!currentWhen.isEmpty) Builder.whenStack.head.localCond else true.B
   }
 }

--- a/src/main/scala/utility/Compatibility.scala
+++ b/src/main/scala/utility/Compatibility.scala
@@ -8,6 +8,6 @@ package chisel3 {
     def currentModule: Option[BaseModule] = Builder.currentModule
 
     // Return the internal implicit whenContext
-    def currentWhen: Option[WhenContext] = Builder.currentWhen
+    def currentWhen: Option[WhenContext] = Builder.whenStack.headOption
   }
 }


### PR DESCRIPTION
I find xiangshan use common assert to check, but sometimes common assert cannot present some useful infomation, such as simulation time, etc. so i add a XSAssert to enhance assert through logUtils, XSAssert is similar to XSError except revert the cond, it will have more infomation to print compare to normal assert(but i dont know xiangshan want this
or not) and it contains the other two change:
- chisel 7.0.0-RC1 remove currentWhen and this change can adapt both chisel 7.0.0-RC1 and 6.6.0
- add currentWhenCond, currentWhenCond is the current when cond && the prev when cond , it can use in LogUtils to allow XSLog present in when Block