### PR TITLE
feat(ChiselTaggedTrace): XSPdb suport & rename PerfCCT to TaggedTrace

### DIFF
--- a/src/main/scala/utility/package.scala
+++ b/src/main/scala/utility/package.scala
@@ -13,4 +13,6 @@ package object utility {
   type SRAMReadBus[T <: Data] = _root_.utility.sram.SRAMReadBus[T]
   @deprecated
   type SRAMWriteBus[T <: Data] = _root_.utility.sram.SRAMWriteBus[T]
+
+  val PerfCCT = utility.TaggedTrace
 }


### PR DESCRIPTION
1.Export the commit trace to XSPdb
2.More standardized naming, PerfCCT -> TaggedTrace
Still keep the perfcct alias