### PR TITLE
feat(constantin): add custom constantin file

### DIFF
--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -152,7 +152,6 @@ object Constantin extends ConstantinParams {
   def addToFileRegisters = {
     FileRegisters.add(s"${objectName}.hpp", getCHeader)
     var cppContext = getInitCpp
-    // cppContext += getPreProcessCpp
     cppContext += initMap.map({a => getCpp(a._1)}).foldLeft("")(_ + _)
     FileRegisters.add(s"${objectName}.cpp", cppContext)
     FileRegisters.add(s"${objectName}.txt", getTXT)

--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -125,70 +125,11 @@ object Constantin extends ConstantinParams {
        |""".stripMargin
   }
 
-  def getPreProcessCpp: String = {
-    s"""
-       |#include <iostream>
-       |#include <fstream>
-       |#include <map>
-       |#include <string>
-       |#include <cstring>
-       |#include <stdint.h>
-       |using namespace std;
-       |
-       |extern map<string, uint64_t> constantinMap;
-       |
-       |void constantinUpdate(string name, uint64_t num){
-       |  if(constantinMap.find(name) == constantinMap.end()){
-       |    cout << "[ERROR] constant does not exist: " << name << ", please check the input." << endl;
-       |    exit(1);
-       |  }
-       |  constantinMap[name] = num;
-       |  return;
-       |}
-       |
-       |void constantinLoad(const char *cst_file) {
-       |  constantinInit();
-       |
-       |  if (cst_file == nullptr || strlen(cst_file) == 0) {
-       |    cout << "[INFO] init for constantin: loaded from init." << endl;
-       |    return;
-       |  }
-       |
-       |  uint64_t num;
-       |  string name;
-       |  if (string(cst_file) == "stdin") {
-       |    cout << "[INFO] stdin for constantin: loaded from stdin." << endl;
-       |    uint64_t total_num;
-       |    cout << "Please input total constant number:" << endl;
-       |    cin >> total_num;
-       |    cout << "Please input each constant ([constant name] [value]):" << endl;
-       |    for (uint64_t i = 0; i < total_num; i++) {
-       |      cin >> name >> num;
-       |      constantinUpdate(name, num);
-       |    }
-       |    return;
-       |  }
-       |
-       |  ifstream cf(cst_file, ios::in);
-       |  if (cf.good()) {
-       |    cout << "[INFO] file for constantin: loaded from " << cst_file << "." << endl;
-       |    while (cf >> name >> num) {
-       |      constantinUpdate(name, num);
-       |    }
-       |    cf.close();
-       |    return;
-       |  }else{
-       |    cerr << "[ERROR] constantin file does not exist: " << cst_file << endl;
-       |    exit(1);
-       |  }
-       |}
-       |""".stripMargin
-  }
-
   def getCpp(constName: String): String = {
     s"""
        |#include <map>
        |#include <string>
+       |#include <iostream>
        |#include <stdint.h>
        |#include <assert.h>
        |using namespace std;
@@ -211,7 +152,7 @@ object Constantin extends ConstantinParams {
   def addToFileRegisters = {
     FileRegisters.add(s"${objectName}.hpp", getCHeader)
     var cppContext = getInitCpp
-    cppContext += getPreProcessCpp
+    // cppContext += getPreProcessCpp
     cppContext += initMap.map({a => getCpp(a._1)}).foldLeft("")(_ + _)
     FileRegisters.add(s"${objectName}.cpp", cppContext)
     FileRegisters.add(s"${objectName}.txt", getTXT)

--- a/src/main/scala/utility/Constantin.scala
+++ b/src/main/scala/utility/Constantin.scala
@@ -21,7 +21,6 @@ import chisel3.util._
 
 trait ConstantinParams {
   def UIntWidth = 64
-  def AutoSolving = false
   def getdpicFunc(constName: String) = {
     s"${constName}_constantin_read"
   }
@@ -132,62 +131,56 @@ object Constantin extends ConstantinParams {
        |#include <fstream>
        |#include <map>
        |#include <string>
-       |#include <cstdlib>
+       |#include <cstring>
        |#include <stdint.h>
        |using namespace std;
        |
-       |fstream cf;
        |extern map<string, uint64_t> constantinMap;
        |
-       |void constantinLoad() {
-       |  constantinInit();
-       |  uint64_t num;
-       |  const char *noop_home = getenv("NOOP_HOME");
-       |#ifdef NOOP_HOME
-       |  if (!noop_home) {
-       |    noop_home = NOOP_HOME;
+       |void constantinUpdate(string name, uint64_t num){
+       |  if(constantinMap.find(name) == constantinMap.end()){
+       |    cout << "[ERROR] constant does not exist: " << name << ", please check the input." << endl;
+       |    exit(1);
        |  }
-       |#endif
-       |  string noop_home_s = noop_home;
-       |  string tmp = noop_home_s + "/build/${objectName}.txt";
-       |  cf.open(tmp.c_str(), ios::in);
-       |  if(cf.good()){
-       |    while (cf >> tmp >> num) {
-       |      constantinMap[tmp] = num;
-       |    }
-       |  }else{
-       |    cout << "[WARNING] " << tmp << " does not exist, so all constants default to initialized values." << endl;
-       |  }
-       |  cf.close();
-       |
+       |  constantinMap[name] = num;
+       |  return;
        |}
-       |""".stripMargin
-  }
-
-  def getPreProcessFromStdInCpp: String = {
-    s"""
-       |#include <iostream>
-       |#include <map>
-       |#include <string>
-       |#include <cstdlib>
-       |#include <stdint.h>
-       |using namespace std;
        |
-       |extern map<string, uint64_t> constantinMap;
-       |
-       |void constantinLoad() {
+       |void constantinLoad(const char *cst_file) {
        |  constantinInit();
-       |  uint64_t num;
-       |  string tmp;
-       |  uint64_t total_num;
-       |  cout << "please input total constant number" << endl;
-       |  cin >> total_num;
-       |  cout << "please input each constant ([constant name] [value])" << endl;
-       |  for(int i=0; i<total_num; i++) {
-       |    cin >> tmp >> num;
-       |    constantinMap[tmp] = num;
+       |
+       |  if (cst_file == nullptr || strlen(cst_file) == 0) {
+       |    cout << "[INFO] init for constantin: loaded from init." << endl;
+       |    return;
        |  }
        |
+       |  uint64_t num;
+       |  string name;
+       |  if (string(cst_file) == "stdin") {
+       |    cout << "[INFO] stdin for constantin: loaded from stdin." << endl;
+       |    uint64_t total_num;
+       |    cout << "Please input total constant number:" << endl;
+       |    cin >> total_num;
+       |    cout << "Please input each constant ([constant name] [value]):" << endl;
+       |    for (uint64_t i = 0; i < total_num; i++) {
+       |      cin >> name >> num;
+       |      constantinUpdate(name, num);
+       |    }
+       |    return;
+       |  }
+       |
+       |  ifstream cf(cst_file, ios::in);
+       |  if (cf.good()) {
+       |    cout << "[INFO] file for constantin: loaded from " << cst_file << "." << endl;
+       |    while (cf >> name >> num) {
+       |      constantinUpdate(name, num);
+       |    }
+       |    cf.close();
+       |    return;
+       |  }else{
+       |    cerr << "[ERROR] constantin file does not exist: " << cst_file << endl;
+       |    exit(1);
+       |  }
        |}
        |""".stripMargin
   }
@@ -218,11 +211,7 @@ object Constantin extends ConstantinParams {
   def addToFileRegisters = {
     FileRegisters.add(s"${objectName}.hpp", getCHeader)
     var cppContext = getInitCpp
-    if (AutoSolving) {
-      cppContext += getPreProcessFromStdInCpp
-    } else {
-      cppContext += getPreProcessCpp
-    }
+    cppContext += getPreProcessCpp
     cppContext += initMap.map({a => getCpp(a._1)}).foldLeft("")(_ + _)
     FileRegisters.add(s"${objectName}.cpp", cppContext)
     FileRegisters.add(s"${objectName}.txt", getTXT)


### PR DESCRIPTION
1. use `void constantinLoad(const char *cst_file);` to support three mode of constantin file: 
    1. **none**: use the initial value.
    2. **stdin**: use the standard input stream.
    3. **custom file path**: use the specified file.
2. use `void constantinUpdate(string name, uint64_t num);` to check the input value, who is guaranteed to change the input is the expected value.

NOTE: all these are removed into `difftest/src/test/csrc/util/constantin_static.cpp`.
