### PR TITLE
feat: add TwoLevelRRArbiter and some BitOperations

### DIFF
--- a/src/main/scala/utility/BitUtils.scala
+++ b/src/main/scala/utility/BitUtils.scala
@@ -406,3 +406,17 @@ object FastAdderComparator {
   def apply(a: UInt, b: UInt, k: UInt): Bool = apply(a, b, false.B, k)
 
 }
+
+object MaskToOH {
+  def apply(mask: Seq[Bool]): UInt = {
+    val oh = VecInit(mask.zipWithIndex.map{
+      case (b, 0) => b
+      case (b, i) => b && !Cat(mask.take(i)).orR
+    }).asUInt
+    oh
+  }
+
+  def apply(mask: UInt): UInt = {
+    apply(mask.asBools)
+  }
+}

--- a/src/main/scala/utility/FastArbiter.scala
+++ b/src/main/scala/utility/FastArbiter.scala
@@ -19,8 +19,12 @@ package utility
 import chisel3._
 import chisel3.util._
 
+class FastArbiterIO[T <: Data](private val gen: T, val n: Int) extends ArbiterIO(gen, n) {
+  val chosenOH = Output(UInt(n.W))
+}
+
 abstract class FastArbiterBase[T <: Data](val gen: T, val n: Int) extends Module {
-  val io = IO(new ArbiterIO[T](gen, n))
+  val io = IO(new FastArbiterIO[T](gen, n))
 
   def maskToOH(seq: Seq[Bool]) = {
     seq.zipWithIndex.map{
@@ -60,6 +64,7 @@ class FastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen, n) 
     case (rdy, grant) => rdy := grant && io.out.ready
   }
 
+  io.chosenOH := chosenOH
   io.chosen := OHToUInt(chosenOH)
 
 }
@@ -102,5 +107,7 @@ class LatchFastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen
 
   io.out.valid := out_valid_reg && valids(OHToUInt(chosen_reg))
   io.out.bits <> out_bits_reg
+
+  io.chosenOH := chosen_reg
   io.chosen := OHToUInt(chosen_reg)
 }

--- a/src/main/scala/utility/FastArbiter.scala
+++ b/src/main/scala/utility/FastArbiter.scala
@@ -19,7 +19,7 @@ package utility
 import chisel3._
 import chisel3.util._
 
-class FastArbiterIO[T <: Data](private val gen: T, val n: Int) extends ArbiterIO(gen, n) {
+class FastArbiterIO[T <: Data](private val gen: T, override val n: Int) extends ArbiterIO(gen, n) {
   val chosenOH = Output(UInt(n.W))
 }
 
@@ -110,4 +110,47 @@ class LatchFastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen
 
   io.chosenOH := chosen_reg
   io.chosen := OHToUInt(chosen_reg)
+}
+
+class TwoLevelRRArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen, n) {
+  if (n == 0) {
+    io.out.valid := false.B
+    io.out.bits := 0.U.asTypeOf(io.out.bits)
+    io.chosen := 0.U
+    io.chosenOH := 0.U
+  } else if (n == 1) {
+    io.out.valid := io.in.head.valid
+    io.out.bits := io.in.head.bits
+    io.in.head.ready := io.out.ready
+    io.chosen := 0.U
+    io.chosenOH := Mux(io.in.head.valid, 1.U, 0.U)
+  } else {
+    val mid = n / 2
+    val rest = n - mid
+    val lowArb = Module(new FastArbiter(gen, mid))
+    val highArb = Module(new FastArbiter(gen, rest))
+    val selLow = RegInit(false.B)
+
+    lowArb.io.in <> io.in.take(mid)
+    highArb.io.in <> io.in.drop(mid)
+
+    val finalSelLow = Mux1H(Seq(
+      (lowArb.io.out.valid && highArb.io.out.valid) -> selLow,
+      (lowArb.io.out.valid && !highArb.io.out.valid) -> true.B,
+      (!lowArb.io.out.valid && highArb.io.out.valid) -> false.B
+    ))
+
+    when (io.out.fire) {
+      selLow := Mux(finalSelLow, !highArb.io.out.valid, lowArb.io.out.valid)
+    }
+
+    io.out.valid := lowArb.io.out.valid || highArb.io.out.valid
+    io.out.bits := Mux(finalSelLow, lowArb.io.out.bits, highArb.io.out.bits)
+    lowArb.io.out.ready := io.out.ready && finalSelLow
+    highArb.io.out.ready := io.out.ready && !finalSelLow
+
+
+    io.chosenOH := Cat(Fill(rest, !finalSelLow) & highArb.io.chosenOH, Fill(mid, finalSelLow).asUInt & lowArb.io.chosenOH)
+    io.chosen := OHToUInt(io.chosenOH)
+  }
 }

--- a/src/main/scala/utility/FastArbiter.scala
+++ b/src/main/scala/utility/FastArbiter.scala
@@ -25,13 +25,6 @@ class FastArbiterIO[T <: Data](private val gen: T, override val n: Int) extends 
 
 abstract class FastArbiterBase[T <: Data](val gen: T, val n: Int) extends Module {
   val io = IO(new FastArbiterIO[T](gen, n))
-
-  def maskToOH(seq: Seq[Bool]) = {
-    seq.zipWithIndex.map{
-      case (b, 0) => b
-      case (b, i) => b && !Cat(seq.take(i)).orR
-    }
-  }
 }
 
 class FastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen, n) {
@@ -52,8 +45,8 @@ class FastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen, n) 
   val rrGrantMask = RegEnable(VecInit((0 until n) map { i =>
     if(i == 0) false.B else chosenOH(i - 1, 0).orR
   }).asUInt, 0.U(n.W), io.out.fire)
-  val rrSelOH = VecInit(maskToOH((rrGrantMask & pendingMask).asBools)).asUInt
-  val firstOneOH = VecInit(maskToOH(valids.asBools)).asUInt
+  val rrSelOH = MaskToOH(rrGrantMask & pendingMask)
+  val firstOneOH = MaskToOH(valids)
   val rrValid = (rrSelOH & valids).orR
   chosenOH := Mux(rrValid, rrSelOH, firstOneOH)
 
@@ -87,8 +80,8 @@ class LatchFastArbiter[T <: Data](gen: T, n: Int) extends FastArbiterBase[T](gen
   val rrGrantMask = RegEnable(VecInit((0 until n) map { i =>
     if(i == 0) false.B else chosenOH(i - 1, 0).orR
   }).asUInt, 0.U(n.W), latch_result)
-  val rrSelOH = VecInit(maskToOH((rrGrantMask & pendingMask).asBools)).asUInt
-  val firstOneOH = VecInit(maskToOH(valids.asBools)).asUInt
+  val rrSelOH = MaskToOH(rrGrantMask & pendingMask)
+  val firstOneOH = MaskToOH(valids)
   val rrValid = (rrSelOH & valids).orR
   chosenOH := Mux(rrValid, rrSelOH, firstOneOH)
 

--- a/src/main/scala/utility/PerfCounterUtils.scala
+++ b/src/main/scala/utility/PerfCounterUtils.scala
@@ -430,6 +430,38 @@ object XSPerfRolling extends HasRegularPerfName {
   }
 }
 
+object ArbPerf {
+  def apply(valids: Seq[Bool], readys: Seq[Bool], outRdy: Bool, name: String)(implicit p: Parameters): Unit = {
+    require(valids.size == readys.size)
+    val n = valids.size
+    if (n == 0) {
+      ()
+    } else {
+      XSPerfHistogram(s"${name}ArbConflict", PopCount(valids), VecInit(valids).asUInt.orR, 1, n + 1)
+      val zeroBuckets = (0.until(n * 2).map(x => (0.U, x)) :+ (0.U, n * 2))
+      valids.zip(readys).zipWithIndex.map { case ((v, r), i) =>
+        val w = RegInit(0.U(64.W))
+        when (!v) {
+          w := 0.U
+        }.elsewhen (v && r) {
+          w := 0.U
+        }.elsewhen (v && !r && outRdy) {
+          w := w + 1.U
+        }
+        0.until(n*2).map(x => ((x.U === w && v && r).asUInt, x)) :+ (((w >= (n*2).U && v && r).asUInt, n*2))
+      }.foldLeft(zeroBuckets) { (left, right) =>
+        left.zip(right).map { case (a, b) => (a._1 + b._1, a._2) }
+      }.foreach { case (cnt, time) =>
+        XSPerfAccumulate(s"${name}ArbWaitTime_${time}", cnt)
+      }
+    }
+  }
+
+  def apply[T <: Data](arb: FastArbiterBase[T], name: String)(implicit p: Parameters): Unit = {
+    apply(arb.io.in.map(_.valid), arb.io.in.map(_.ready), arb.io.out.ready, name)
+  }
+}
+
 object XSPerfPrint {
   // XSPerf depends on LogPerfIO passed from Top, defer apply and collect to endpoint
   // XSLog is also deferred apply in another module, pass original module for pathName


### PR DESCRIPTION
Add chosenOH in FastArbBase io as output.
Add TwoLevelRRArbiter composed of two FastArbiter, reducing the logic levels of maskToOH(mask).
Add new Performance counter to measure the fairness of Arbiter.
Add new BitOperation MaskToOH.