### PR TITLE
fix(HwSort): update sorting logic to prioritize valid elements

### DIFF
--- a/src/main/scala/utility/Sort.scala
+++ b/src/main/scala/utility/Sort.scala
@@ -50,8 +50,8 @@ object DataWithPtr {
 object HwSort {
   /** Hardware Sort, a small combinational sorter that can sort up to 4 data by Ptr.
     * 
-    * The sort is stable. That is, elements that are invalid or equal (as determined by `cmp` function),
-    * appear in the same order in the sorted sequence as in the original.
+    * Valid elements are placed before invalid elements and sorted by `cmp`.
+    * The order of equal elements and invalid elements is not guaranteed to be stable.
     * 
     * @tparam A default Data
     * @tparam B the type where "<" is defined, here it refers to [[CircularQueuePtr]]
@@ -83,8 +83,8 @@ object HwSort {
       res := xVec
     } else if (size == 2) {
       // total ~20 ps
-      // 1 is older than 0 (only when 0 and 1 are both valid)
-      val swap = xVec(0).valid && xVec(1).valid && cmp(xVec(1).ptr, xVec(0).ptr)
+      // Put valid elements first. If both are valid, sort them by cmp.
+      val swap = xVec(1).valid && (!xVec(0).valid || cmp(xVec(1).ptr, xVec(0).ptr))
       when(swap) {
         res(0) := xVec(1)
         res(1) := xVec(0)
@@ -136,10 +136,10 @@ object HwSort {
       row2(3) := tmp2_2(1)
 
       val tmp3_1 = apply(VecInit(row2(0), row2(1)))
-      row3(1) := tmp3_1(0)
-      row3(2) := tmp3_1(1)
+      row3(0) := tmp3_1(0)
+      row3(1) := tmp3_1(1)
       val tmp3_2 = apply(VecInit(row2(2), row2(3)))
-      row3(0) := tmp3_2(0)
+      row3(2) := tmp3_2(0)
       row3(3) := tmp3_2(1)
 
       res := row3


### PR DESCRIPTION
## 1

HwSort only swapped two entries when both were valid. An invalid entry could block valid entries behind it, so valid entries were not guaranteed to be packed together or sorted.

Example:
  in0: valid,   ptr = 10
  in1: invalid, ptr = X
  in2: valid,   ptr = 5

  The old logic could keep this order:

  valid ptr=10, invalid, valid ptr=5

Solution: change the base 2-entry compare-swap to valid-first ordering:

  `val swap = xVec(1).valid && (!xVec(0).valid || cmp(xVec(1).ptr, xVec(0).ptr))`

New behavior: valid entries are moved to the front and sorted by cmp. Equal keys and invalid entries are not guaranteed to be stable.

## 2

The old 4-way final-stage wiring was incorrect: it compared (0,1) but wrote the result to (1,2), and compared (2,3) but wrote the result to (0,3).

This could corrupt even already sorted inputs:

  input  = [0, 1, 2, 3]
  output = [2, 0, 1, 3]

  The fix writes each compare-swap result back to its matching lanes:

  tmp3_1 -> row3(0), row3(1)
  tmp3_2 -> row3(2), row3(3)