### PR TITLE
fix(tllogger): log PutFull data on A channel

### DIFF
--- a/src/main/scala/utility/TLUtils/TLLogger.scala
+++ b/src/main/scala/utility/TLUtils/TLLogger.scala
@@ -110,6 +110,9 @@ object TLLogger {
 
   def logA(log: TLLog, a: TLBundleA) = {
     writeChannel(log, a)
+    when (a.opcode(2,1) === TLMessages.PutFullData(2,1)) {
+      log.data := a.data.asTypeOf(log.data)
+    }
   }
 
   def logB(log: TLLog, b: TLBundleB) = {


### PR DESCRIPTION
We support Put for XSAI, so log Put data in TLLogger is required for checking data correctness

----
This pull request introduces a targeted update to the logging functionality in the TileLink utility logger. The main change ensures that data is only logged for specific message types, improving both the accuracy and efficiency of logging.

Logging improvements:

* Updated the `logA` method in `TLLogger` to assign `a.data` to `log.data` only when the opcode matches `TLMessages.PutFullData`, ensuring that data is logged selectively for relevant message types.